### PR TITLE
Fixes #24 by updating function JSDoc annotation.

### DIFF
--- a/closure/goog/ui/ac/inputhandler.js
+++ b/closure/goog/ui/ac/inputhandler.js
@@ -437,7 +437,7 @@ goog.ui.ac.InputHandler.prototype.setCursorPosition = function(pos) {
  * should be a textarea, input box, or other focusable element with the
  * same interface.
  * @param {Element|goog.events.EventTarget} target An element to attach the
- *     input handler too.
+ *     input handler to.
  */
 goog.ui.ac.InputHandler.prototype.attachInput = function(target) {
   if (goog.dom.isElement(target)) {


### PR DESCRIPTION
Would be helpful if [`ui.ac.InputHandle` generated docs](http://docs.closure-library.googlecode.com/git/class_goog_ui_ac_InputHandler.html) are updated to avoid any confusion for `goog.ui.ac.InputHandler.prototype.attachInput` method.
