### PR TITLE
Correct goog.structs.Pool minCount default

### DIFF
--- a/closure/goog/net/xhriopool.js
+++ b/closure/goog/net/xhriopool.js
@@ -30,7 +30,7 @@ goog.require('goog.structs.PriorityPool');
  * A pool of XhrIo objects.
  * @param {goog.structs.Map=} opt_headers Map of default headers to add to every
  *     request.
- * @param {number=} opt_minCount Minimum number of objects (Default: 1).
+ * @param {number=} opt_minCount Minimum number of objects (Default: 0).
  * @param {number=} opt_maxCount Maximum number of objects (Default: 10).
  * @constructor
  * @extends {goog.structs.PriorityPool}

--- a/closure/goog/net/xhrmanager.js
+++ b/closure/goog/net/xhrmanager.js
@@ -51,7 +51,7 @@ goog.require('goog.structs.Map');
  * @param {number=} opt_maxRetries Max. number of retries (Default: 1).
  * @param {goog.structs.Map=} opt_headers Map of default headers to add to every
  *     request.
- * @param {number=} opt_minCount Min. number of objects (Default: 1).
+ * @param {number=} opt_minCount Min. number of objects (Default: 0).
  * @param {number=} opt_maxCount Max. number of objects (Default: 10).
  * @param {number=} opt_timeoutInterval Timeout (in ms) before aborting an
  *     attempt (Default: 0ms).

--- a/closure/goog/structs/pool.js
+++ b/closure/goog/structs/pool.js
@@ -31,7 +31,7 @@ goog.require('goog.structs.Set');
 
 /**
  * A generic pool class. If min is greater than max, an error is thrown.
- * @param {number=} opt_minCount Min. number of objects (Default: 1).
+ * @param {number=} opt_minCount Min. number of objects (Default: 0).
  * @param {number=} opt_maxCount Max. number of objects (Default: 10).
  * @constructor
  * @extends {goog.Disposable}

--- a/closure/goog/structs/prioritypool.js
+++ b/closure/goog/structs/prioritypool.js
@@ -29,7 +29,7 @@ goog.require('goog.structs.PriorityQueue');
 
 /**
  * A generic pool class. If max is greater than min, an error is thrown.
- * @param {number=} opt_minCount Min. number of objects (Default: 1).
+ * @param {number=} opt_minCount Min. number of objects (Default: 0).
  * @param {number=} opt_maxCount Max. number of objects (Default: 10).
  * @constructor
  * @extends {goog.structs.Pool.<VALUE>}


### PR DESCRIPTION
The JSDoc's state that `goog.structs.Pool`'s `minCount` is `1` by default.
However, the specific source file tells us that

> this.minCount_ = opt_minCount || 0;