### PR TITLE
Add goog.array.sortBy

### DIFF
--- a/closure/goog/array/array.js
+++ b/closure/goog/array/array.js
@@ -1151,6 +1151,42 @@ goog.array.stableSort = function(arr, opt_compareFn) {
 
 
 /**
+ * Sorts an array using a generated sorting key for each element. The keys are
+ * compared using an optional comparison function, which defaults to
+ * <code>goog.array.defaultCompare</code>.
+ *
+ * The key function is called only once for each element, in contrast to
+ * comparison functions which may be called more times during sorting.
+ *
+ * For example, to sort strings case-insensitively, the .toLowerCase() function
+ * can be called only once per string.
+ * <code>
+ * goog.array.sortBy(['foo', 'bar', 'FooBar'], function(str) {
+ *   return str.toLowerCase();
+ * });
+ * </code>
+ *
+ * @param {Array.<T>} arr An array of objects to sort.
+ * @param {function(T):*} key The function to calculate the sorting key.
+ * @param {Function=} opt_compareFn The function to use to compare key values.
+ * @template T
+ */
+goog.array.sortBy = function(arr, keyFn, opt_compareFn) {
+  var objects = goog.array.map(arr, function(elem, i) {
+    // could use Arrays instead, but they aren't faster
+    // http://jsperf.com/sort-container/3
+    return {'a':keyFn(elem), 'b':i};
+  });
+  goog.array.sortObjectsByKey(objects, 'a', opt_compareFn);
+
+  var copy = goog.array.clone(arr);
+  goog.array.forEach(objects, function(obj, i) {
+    arr[i] = copy[obj['b']];
+  });
+};
+
+
+/**
  * Sorts an array of objects by the specified object key and compare
  * function. If no compare function is provided, the key values are
  * compared in ascending order using <code>goog.array.defaultCompare</code>.

--- a/closure/goog/array/array_test.js
+++ b/closure/goog/array/array_test.js
@@ -1508,6 +1508,24 @@ function testArrayFlatten() {
   assertArrayEquals([], goog.array.flatten([]));
 }
 
+function testSortBy() {
+  var array = ['foo', 'bar', 'FooBar'];
+  goog.array.sortBy(array, function(str) {
+    return str.toLowerCase();
+  });
+  assertArrayEquals(['bar', 'foo', 'FooBar'], array);
+}
+
+function testSortByWithCompareFunction() {
+  var array = ['foo', 'bar', 'FooBar'];
+  goog.array.sortBy(array, function(str) {
+    return str.toLowerCase();
+  }, function(a, b) {
+    return -goog.array.defaultCompare(a, b);
+  });
+  assertArrayEquals(['FooBar', 'foo', 'bar'], array);
+}
+
 function testSortObjectsByKey() {
   var sortedArray = buildSortedObjectArray(4);
   var objects =


### PR DESCRIPTION
The motivation is making improving clarity and performance of some sorts by using the [Schwartzian transform](https://en.wikipedia.org/wiki/Schwartzian_transform).

Analogous functions are Perl's sort, Python's [`sorted`](https://docs.python.org/3/library/functions.html#sorted) or Scala's [`sortBy`](http://www.scala-lang.org/api/2.10.3/index.html#scala.collection.SeqLike).

For example, the former way of sorting strings case-insensitively were:

```
goog.array.sort(array, goog.string.caseInsensitiveCompare)
```

which sacrifices performance by calling `String(str).toLowerCase()` twice for every comparison. (In practice, `toLowerCase` is very fast for strings of reasonable length, but you could imagine a more involved calculation.)

Or,

```
var objects = goog.array.map(array, function(str, i) {
  return {'key':str.toLowerCase(), 'value':i};
});
goog.array.sortObjectsByKey(objects, 'key');

var tmp = goog.array.clone(arr);
goog.array.forEach(objects, function(obj, i) {
  arr[i] = tmp[obj['value']];
});
```

which sacrifices clarity. (This last example could be made a bit more intuitive by by not requiring an in-place sort, but it's still messy.)

This change allows callers to simply use

```
goog.array.sortBy(array, function(str) {
  return str.toLowerCase();
});
```

---

I was not sure whether `goog.array.sortBy` or `goog.array.sortByKey` would be more clear. The second, for better or worse, resembles `goog.array.sortObjectsByKey`. I thought that they "key" might confuse callers with thinking of actual Javascript keys, objects, etc. (which are not visible to them), so I went with `sortBy`, but I have no strong feelings about this.
