### PR TITLE
Free memory in goog.functions.cacheReturnValue

### DIFF
--- a/closure/goog/functions/functions.js
+++ b/closure/goog/functions/functions.js
@@ -293,17 +293,17 @@ goog.define('goog.functions.CACHE_RETURN_VALUE', true);
  * @template T
  */
 goog.functions.cacheReturnValue = function(fn) {
-  var called = false;
+  var fn2 = fn; // prevents a type error later when we set it to undefined
   var value;
 
   return function() {
     if (!goog.functions.CACHE_RETURN_VALUE) {
-      return fn();
+      return fn2();
     }
 
-    if (!called) {
-      value = fn();
-      called = true;
+    if (fn2) {
+      value = fn2();
+      fn2 = undefined; // free memory
     }
 
     return value;


### PR DESCRIPTION
 A closure can retain a large amount of memory. This discards the reference to the wrapped function once it is no longer needed.

`var fn2 = fn;` was the best way I saw of overcoming the type error.

Removing the the `called` variable was not necessary, but it minimized the number of variables and code.
