### PR TITLE
Prefer vm instead of process binding evals

### DIFF
--- a/closure/goog/bootstrap/nodejs.js
+++ b/closure/goog/bootstrap/nodejs.js
@@ -42,6 +42,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var vm = require('vm');
 
 
 /**
@@ -66,8 +67,7 @@ global.CLOSURE_IMPORT_SCRIPT = function(src) {
 
 // Declared here so it can be used to require base.js
 function nodeGlobalRequire(file) {
-  process.binding('evals').NodeScript.runInThisContext.call(
-      global, fs.readFileSync(file), file);
+  new vm.Script(fs.readFileSync(file), { filename: file }).runInThisContext();
 }
 
 


### PR DESCRIPTION
`require('vm')` should be preferred over `process.bindings('evals')`. The
latter has been removed in node 0.11.