### PR TITLE
Update numberformatsymbolsext.js

### DIFF
--- a/closure/goog/i18n/numberformatsymbolsext.js
+++ b/closure/goog/i18n/numberformatsymbolsext.js
@@ -4143,8 +4143,8 @@ goog.i18n.NumberFormatSymbols_es_GQ = {
  * @enum {string}
  */
 goog.i18n.NumberFormatSymbols_es_GT = {
-  DECIMAL_SEP: ',',
-  GROUP_SEP: '.',
+  DECIMAL_SEP: '.',
+  GROUP_SEP: ',',
   PERCENT: '%',
   ZERO_DIGIT: '0',
   PLUS_SIGN: '+',
@@ -4156,7 +4156,7 @@ goog.i18n.NumberFormatSymbols_es_GT = {
   DECIMAL_PATTERN: '#,##0.###',
   SCIENTIFIC_PATTERN: '#E0',
   PERCENT_PATTERN: '#,##0%',
-  CURRENCY_PATTERN: '#,##0.00\u00A0\u00A4',
+  CURRENCY_PATTERN: '\u00A4#,##0.00',
   DEF_CURRENCY_CODE: 'GTQ'
 };
 


### PR DESCRIPTION
Changes needed to get the correct currency format for Guatemalan Quetzal.  Correct format: 

Q1,234.56
