### PR TITLE
Stop webkitCancelRequestAnimationFrame warning.

### DIFF
--- a/closure/goog/async/animationdelay.js
+++ b/closure/goog/async/animationdelay.js
@@ -262,7 +262,8 @@ goog.async.AnimationDelay.prototype.getRaf_ = function() {
  */
 goog.async.AnimationDelay.prototype.getCancelRaf_ = function() {
   var win = this.win_;
-  return win.cancelRequestAnimationFrame ||
+  return win.cancelAnimationFrame ||
+      win.cancelRequestAnimationFrame ||
       win.webkitCancelRequestAnimationFrame ||
       win.mozCancelRequestAnimationFrame ||
       win.oCancelRequestAnimationFrame ||


### PR DESCRIPTION
Stops ''webkitCancelRequestAnimationFrame' is vendor-specific. Please use the standard 'cancelAnimationFrame' instead.'
