### PR TITLE
Add an addFinally method to Deferreds

### DIFF
--- a/third_party/closure/goog/mochikit/async/deferred.js
+++ b/third_party/closure/goog/mochikit/async/deferred.js
@@ -434,6 +434,25 @@ goog.async.Deferred.prototype.addBoth = function(f, opt_scope) {
 
 
 /**
+ * Like addBoth, but propagates uncaught exceptions in the errback.
+ *
+ * @param {!function(this:T,?):?} f The function to be called on any result.
+ * @param {T=} opt_scope An optional scope to call the function in.
+ * @return {!goog.async.Deferred.<VALUE>} This Deferred.
+ * @template T
+ */
+goog.async.Deferred.prototype.addFinally = function (f, opt_scope) {
+  return this.addCallbacks(f, function (err) {
+    var result = f.call(this, err)
+    if (!goog.isDef(result)) {
+      throw err
+    }
+    return result
+  }, opt_scope)
+};
+
+
+/**
  * Registers a callback function and an errback function at the same position
  * in the execution sequence. Only one of these functions will execute,
  * depending on the error state during the execution sequence.

--- a/third_party/closure/goog/mochikit/async/deferred_test.html
+++ b/third_party/closure/goog/mochikit/async/deferred_test.html
@@ -1065,6 +1065,38 @@ function testThenableInterface() {
   var d = new Deferred();
   assertTrue(goog.Thenable.isImplementedBy(d));
 }
+
+function testAddBothPropagatesToErrback() {
+  var log = [];
+  var deferred = new goog.async.Deferred();
+  deferred.addBoth(goog.nullFunction);
+  deferred.addErrback(function () {
+    log.push('errback');
+  });
+  deferred.errback(new Error('my error'));
+
+  mockClock.tick(1);
+  assertArrayEquals(['errback'], log);
+}
+
+function testAddBothDoesNotPropagateUncaughtExceptions() {
+  var deferred = new goog.async.Deferred();
+  deferred.addBoth(goog.nullFunction);
+  deferred.errback(new Error('my error'));
+  mockClock.tick(1);
+}
+
+function testAddFinally() {
+  var deferred = new goog.async.Deferred();
+  deferred.addFinally(goog.nullFunction);
+  deferred.errback(new Error('my error'));
+
+  try {
+    mockClock.tick(1);
+  } catch (e) {
+    assertEquals('my error', e.message);
+  }
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
Add an addFinally method to Deferreds, to do cleanup without inadvertently disrupting uncaught error propagation.

We've found this useful, because this is how people were using addBoth in practice (for 'finally'-like cleanup jobs)