### PR TITLE
Handle Multiple Number Groupings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,5 @@ Mike Dunn <dunn74@gmail.com>
 Kengo Toda <skypencil@gmail.com>
 Remember The Milk Inc.
 Anish Visaria <anishvisaria98@gmail.com>
+John Huân Vũ <jvu.calpoly@gmail.com>
 

--- a/closure/goog/i18n/numberformat.js
+++ b/closure/goog/i18n/numberformat.js
@@ -86,8 +86,16 @@ goog.i18n.NumberFormat = function(pattern, opt_currency, opt_currencyStyle) {
   // The multiplier for use in percent, per mille, etc.
   /** @private {number} */
   this.multiplier_ = 1;
-  /** @private {number} */
-  this.groupingSize_ = 3;
+
+  /**
+   * The grouping array is used to store the values of each number group
+   * following left of the decimal place. For example, a number group with
+   * goog.i18n.NumberFormat('#,##,###') should have [3,2] where 2 is the
+   * repeated number group following a fixed number grouping of size 3.
+   * @private {!Array<number>}
+   */
+  this.groupingArray_ = [];
+
   /** @private {boolean} */
   this.decimalSeparatorAlwaysShown_ = false;
   /** @private {boolean} */
@@ -580,6 +588,159 @@ goog.i18n.NumberFormat.prototype.roundNumber_ = function(number) {
 
 
 /**
+ * Formats a number with the appropriate groupings when there are repeating
+ * digits present. Repeating digits exists when the length of the digits left
+ * of the decimal place exceeds the number of non-repeating digits.
+ *
+ * Formats a number by iterating through the integer number (intPart) from the
+ * most left of the decimal place by inserting the appropriate number grouping
+ * separator for the repeating digits until all of the repeating digits is
+ * iterated. Then iterate through the non-repeating digits by inserting the
+ * appropriate number grouping separator until all the non-repeating digits
+ * is iterated through.
+ *
+ * In the number grouping concept, anything left of the decimal
+ * place is followed by non-repeating digits and then repeating digits. If the
+ * pattern is #,##,###, then we first (from the left of the decimal place) have
+ * a non-repeating digit of size 3 followed by repeating digits of size 2
+ * separated by a thousand separator. If the length of the digits are six or
+ * more, there may be repeating digits required. For example, the value of
+ * 12345678 would format as 1,23,45,678 where the repeating digit is length 2.
+ *
+ * @param {!Array<string>} parts An array to build the 'parts' of the formatted
+ *  number including the values and separators.
+ * @param {number} zeroCode The value of the zero digit whether or not
+ *  goog.i18n.NumberFormat.enforceAsciiDigits_ is enforced.
+ * @param {string} intPart The integer representation of the number to be
+ *  formatted and referenced.
+ * @param {!Array<number>} groupingArray The array of numbers to determine the
+ *  grouping of repeated and non-repeated digits.
+ * @param {number} repeatedDigitLen The length of the repeated digits left of
+ *  the non-repeating digits left of the decimal.
+ * @return {!Array<string>} Returns the resulting parts variable containing
+ *  how numbers are to be grouped and appear.
+ * @private
+ */
+goog.i18n.NumberFormat.formatNumberGroupingRepeatingDigitsParts_ =
+    function(parts, zeroCode, intPart, groupingArray, repeatedDigitLen) {
+  // Keep track of how much has been completed on the non repeated groups
+  var nonRepeatedGroupCompleteCount = 0;
+  var currentGroupSizeIndex = 0;
+  var currentGroupSize = 0;
+
+  var grouping = goog.i18n.NumberFormatSymbols.GROUP_SEP;
+  var digitLen = intPart.length;
+
+  // There are repeating digits and non-repeating digits
+  for (var i = 0; i < digitLen; i++) {
+    parts.push(String.fromCharCode(zeroCode + intPart.charAt(i) * 1));
+    if (digitLen - i > 1) {
+      currentGroupSize = groupingArray[currentGroupSizeIndex];
+      if (i < repeatedDigitLen) {
+        // Process the left side (the repeated number groups)
+        var repeatedDigitIndex = repeatedDigitLen - i;
+        // Edge case if there's a number grouping asking for "1" group at
+        // a time; otherwise, if the remainder is 1, there's the separator
+        if (currentGroupSize === 1 ||
+            (currentGroupSize > 0 &&
+            (repeatedDigitIndex % currentGroupSize) === 1)) {
+          parts.push(grouping);
+        }
+      } else if (currentGroupSizeIndex < groupingArray.length) {
+        // Process the right side (the non-repeated fixed number groups)
+        if (i === repeatedDigitLen) {
+          // Increase the group index because a separator
+          // has previously added in the earlier logic
+          currentGroupSizeIndex += 1;
+        } else if (
+            currentGroupSize === i - repeatedDigitLen -
+            nonRepeatedGroupCompleteCount + 1) {
+          // Otherwise, just iterate to the right side and
+          // add a separator once the length matches to the expected
+          parts.push(grouping);
+          // Keep track of what has been completed on the right
+          nonRepeatedGroupCompleteCount += currentGroupSize;
+          currentGroupSizeIndex += 1; // Get to the next number grouping
+        }
+      }
+    }
+  }
+  return parts;
+};
+
+
+/**
+ * Formats a number with the appropriate groupings when there are no repeating
+ * digits present. Non-repeating digits exists when the length of the digits
+ * left of the decimal place is equal or lesser than the length of
+ * non-repeating digits.
+ *
+ * Formats a number by iterating through the integer number (intPart) from the
+ * right most non-repeating number group of the decimal place. For each group,
+ * inserting the appropriate number grouping separator for the non-repeating
+ * digits until the number is completely iterated.
+ *
+ * In the number grouping concept, anything left of the decimal
+ * place is followed by non-repeating digits and then repeating digits. If the
+ * pattern is #,##,###, then we first (from the left of the decimal place) have
+ * a non-repeating digit of size 3 followed by repeating digits of size 2
+ * separated by a thousand separator. If the length of the digits are five or
+ * less, there won't be any repeating digits required. For example, the value
+ * of 12345 would be formatted as 12,345 where the non-repeating digit is of
+ * length 3.
+ *
+ * @param {!Array<string>} parts An array to build the 'parts' of the formatted
+ *  number including the values and separators.
+ * @param {number} zeroCode The value of the zero digit whether or not
+ *  goog.i18n.NumberFormat.enforceAsciiDigits_ is enforced.
+ * @param {string} intPart The integer representation of the number to be
+ *  formatted and referenced.
+ * @param {!Array<number>} groupingArray The array of numbers to determine the
+ *  grouping of repeated and non-repeated digits.
+ * @return {!Array<string>} Returns the resulting parts variable containing
+ *  how numbers are to be grouped and appear.
+ * @private
+ */
+goog.i18n.NumberFormat.formatNumberGroupingNonRepeatingDigitsParts_ =
+    function(parts, zeroCode, intPart, groupingArray) {
+  // Keep track of how much has been completed on the non repeated groups
+  var grouping = goog.i18n.NumberFormatSymbols.GROUP_SEP;
+  var currentGroupSizeIndex;
+  var currentGroupSize = 0;
+  var digitLenLeft = intPart.length;
+  var rightToLeftParts = [];
+
+  // Start from the right most non-repeating group and work inwards
+  for (currentGroupSizeIndex = groupingArray.length - 1;
+       currentGroupSizeIndex >= 0 && digitLenLeft > 0;
+       currentGroupSizeIndex--) {
+    currentGroupSize = groupingArray[currentGroupSizeIndex];
+    // Iterate from the right most digit
+    for (var rightDigitIndex = 0;
+         rightDigitIndex < currentGroupSize && (
+         (digitLenLeft - rightDigitIndex - 1) >= 0);
+         rightDigitIndex++) {
+      rightToLeftParts.push(
+          String.fromCharCode(
+              zeroCode + intPart.charAt(
+                  digitLenLeft - rightDigitIndex - 1) * 1));
+    }
+    // Update the number of digits left
+    digitLenLeft -= currentGroupSize;
+    if (digitLenLeft > 0) {
+      rightToLeftParts.push(grouping);
+    }
+  }
+  // Reverse and push onto the remaining parts
+  rightToLeftParts.reverse().forEach(function(item) {
+    parts.push(item);
+  });
+
+  return parts;
+};
+
+
+/**
  * Formats a Number in fraction format.
  *
  * @param {number} number
@@ -593,6 +754,10 @@ goog.i18n.NumberFormat.prototype.subformatFixed_ =
     function(number, minIntDigits, parts) {
   if (this.minimumFractionDigits_ > this.maximumFractionDigits_) {
     throw Error('Min value must be less than max value');
+  }
+
+  if (parts === null) {
+    parts = [];
   }
 
   var rounded = this.roundNumber_(number);
@@ -622,24 +787,37 @@ goog.i18n.NumberFormat.prototype.subformatFixed_ =
   intPart = translatableInt + intPart;
 
   var decimal = goog.i18n.NumberFormatSymbols.DECIMAL_SEP;
-  var grouping = goog.i18n.NumberFormatSymbols.GROUP_SEP;
   var zeroCode = goog.i18n.NumberFormat.enforceAsciiDigits_ ?
-                 48  /* ascii '0' */ :
-                 goog.i18n.NumberFormatSymbols.ZERO_DIGIT.charCodeAt(0);
+      48  /* ascii '0' */ :
+      goog.i18n.NumberFormatSymbols.ZERO_DIGIT.charCodeAt(0);
   var digitLen = intPart.length;
+  var nonRepeatedGroupCount = 0;
 
   if (intValue > 0 || minIntDigits > 0) {
     for (var i = digitLen; i < minIntDigits; i++) {
       parts.push(String.fromCharCode(zeroCode));
     }
 
-    for (var i = 0; i < digitLen; i++) {
-      parts.push(String.fromCharCode(zeroCode + intPart.charAt(i) * 1));
-
-      if (digitLen - i > 1 && this.groupingSize_ > 0 &&
-          ((digitLen - i) % this.groupingSize_ == 1)) {
-        parts.push(grouping);
+    // If there's more than 1 number grouping,
+    // figure out the length of the non-repeated groupings (on the right)
+    if (this.groupingArray_.length >= 2) {
+      for (var j = 1; j < this.groupingArray_.length; j++) {
+        nonRepeatedGroupCount += this.groupingArray_[j];
       }
+    }
+
+    // Anything left of the fixed number grouping is repeated,
+    // figure out the length of repeated groupings (on the left)
+    var repeatedDigitLen = digitLen - nonRepeatedGroupCount;
+    if (repeatedDigitLen > 0) {
+      // There are repeating digits and non-repeating digits
+      parts = goog.i18n.NumberFormat.formatNumberGroupingRepeatingDigitsParts_(
+          parts, zeroCode, intPart, this.groupingArray_, repeatedDigitLen);
+    } else {
+      // There are no repeating digits and only non-repeating digits
+      parts =
+          goog.i18n.NumberFormat.formatNumberGroupingNonRepeatingDigitsParts_(
+          parts, zeroCode, intPart, this.groupingArray_);
     }
   } else if (!fractionPresent) {
     // If there is no fraction present, and we haven't printed any
@@ -685,7 +863,7 @@ goog.i18n.NumberFormat.prototype.addExponentPart_ = function(exponent, parts) {
 
   var exponentDigits = '' + exponent;
   var zeroChar = goog.i18n.NumberFormat.enforceAsciiDigits_ ? '0' :
-                 goog.i18n.NumberFormatSymbols.ZERO_DIGIT;
+      goog.i18n.NumberFormatSymbols.ZERO_DIGIT;
   for (var i = exponentDigits.length; i < this.minExponentDigits_; i++) {
     parts.push(zeroChar);
   }
@@ -696,7 +874,7 @@ goog.i18n.NumberFormat.prototype.addExponentPart_ = function(exponent, parts) {
 /**
  * Formats Number in exponential format.
  *
- * @param {number} number Value need to be formated.
+ * @param {number} number Value need to be formatted.
  * @param {Array<string>} parts The array that holds the pieces of formatted
  *     string. This function will append more formatted pieces to the array.
  * @private
@@ -961,7 +1139,6 @@ goog.i18n.NumberFormat.prototype.parseTrunk_ = function(pattern, pos) {
   var zeroDigitCount = 0;
   var digitRightCount = 0;
   var groupingCount = -1;
-
   var len = pattern.length;
   for (var loop = true; pos[0] < len && loop; pos[0]++) {
     var ch = pattern.charAt(pos[0]);
@@ -986,19 +1163,22 @@ goog.i18n.NumberFormat.prototype.parseTrunk_ = function(pattern, pos) {
         }
         break;
       case goog.i18n.NumberFormat.PATTERN_GROUPING_SEPARATOR_:
+        if (groupingCount > 0) {
+          this.groupingArray_.push(groupingCount);
+        }
         groupingCount = 0;
         break;
       case goog.i18n.NumberFormat.PATTERN_DECIMAL_SEPARATOR_:
         if (decimalPos >= 0) {
           throw Error('Multiple decimal separators in pattern "' +
-                      pattern + '"');
+              pattern + '"');
         }
         decimalPos = digitLeftCount + zeroDigitCount + digitRightCount;
         break;
       case goog.i18n.NumberFormat.PATTERN_EXPONENT_:
         if (this.useExponentialNotation_) {
           throw Error('Multiple exponential symbols in pattern "' +
-                      pattern + '"');
+              pattern + '"');
         }
         this.useExponentialNotation_ = true;
         this.minExponentDigits_ = 0;
@@ -1013,7 +1193,7 @@ goog.i18n.NumberFormat.prototype.parseTrunk_ = function(pattern, pos) {
         // Use lookahead to parse out the exponential part
         // of the pattern, then jump into phase 2.
         while ((pos[0] + 1) < len && pattern.charAt(pos[0] + 1) ==
-               goog.i18n.NumberFormat.PATTERN_ZERO_DIGIT_) {
+            goog.i18n.NumberFormat.PATTERN_ZERO_DIGIT_) {
           pos[0]++;
           this.minExponentDigits_++;
         }
@@ -1045,7 +1225,7 @@ goog.i18n.NumberFormat.prototype.parseTrunk_ = function(pattern, pos) {
   // Do syntax checking on the digits.
   if (decimalPos < 0 && digitRightCount > 0 ||
       decimalPos >= 0 && (decimalPos < digitLeftCount ||
-                          decimalPos > digitLeftCount + zeroDigitCount) ||
+      decimalPos > digitLeftCount + zeroDigitCount) ||
       groupingCount == 0) {
     throw Error('Malformed pattern "' + pattern + '"');
   }
@@ -1073,9 +1253,10 @@ goog.i18n.NumberFormat.prototype.parseTrunk_ = function(pattern, pos) {
     }
   }
 
-  this.groupingSize_ = Math.max(0, groupingCount);
+  // Add another number grouping at the end
+  this.groupingArray_.push(Math.max(0, groupingCount));
   this.decimalSeparatorAlwaysShown_ = decimalPos == 0 ||
-                                      decimalPos == totalDigits;
+      decimalPos == totalDigits;
 };
 
 

--- a/closure/goog/i18n/numberformat_test.js
+++ b/closure/goog/i18n/numberformat_test.js
@@ -55,7 +55,7 @@ function tearDown() {
 
 function veryBigNumberCompare(str1, str2) {
   return str1.length == str2.length &&
-         str1.substring(0, 8) == str2.substring(0, 8);
+      str1.substring(0, 8) == str2.substring(0, 8);
 }
 
 function testVeryBigNumber() {
@@ -64,7 +64,6 @@ function testVeryBigNumber() {
   str = fmt.format(1785599999999999888888888888888);
   // when comparing big number, various platform have small different in
   // precision. We have to tolerate that using veryBigNumberCompare.
-  var expected = '$1,785,599,999,999,999,400,000,000,000,000.00';
   assertTrue(veryBigNumberCompare(
       '$1,785,599,999,999,999,400,000,000,000,000.00', str));
   str = fmt.format(1.7856E30);
@@ -266,6 +265,7 @@ function testGrouping() {
   var fmt = new goog.i18n.NumberFormat('#,###');
   str = fmt.format(1234567890);
   assertEquals('1,234,567,890', str);
+
   fmt = new goog.i18n.NumberFormat('#,####');
   str = fmt.format(1234567890);
   assertEquals('12,3456,7890', str);
@@ -273,6 +273,160 @@ function testGrouping() {
   fmt = new goog.i18n.NumberFormat('#');
   str = fmt.format(1234567890);
   assertEquals('1234567890', str);
+}
+
+function testIndiaNumberGrouping() {
+  // Test for a known grouping used and recognized in India
+  var fmt = new goog.i18n.NumberFormat('#,##,###');
+  var str = fmt.format(1);
+  assertEquals('1', str);
+  str = fmt.format(12);
+  assertEquals('12', str);
+  str = fmt.format(123);
+  assertEquals('123', str);
+  str = fmt.format(1234);
+  assertEquals('1,234', str);
+  str = fmt.format(12345);
+  assertEquals('12,345', str);
+  str = fmt.format(123456);
+  assertEquals('1,23,456', str);
+  str = fmt.format(1234567);
+  assertEquals('12,34,567', str);
+  str = fmt.format(12345678);
+  assertEquals('1,23,45,678', str);
+  str = fmt.format(123456789);
+  assertEquals('12,34,56,789', str);
+  str = fmt.format(1234567890);
+  assertEquals('1,23,45,67,890', str);
+  str = fmt.format(0);
+  assertEquals('0', str);
+  str = fmt.format(-1);
+  assertEquals('-1', str);
+  str = fmt.format(-12);
+  assertEquals('-12', str);
+  str = fmt.format(-123);
+  assertEquals('-123', str);
+  str = fmt.format(-1234);
+  assertEquals('-1,234', str);
+  str = fmt.format(-12345);
+  assertEquals('-12,345', str);
+  str = fmt.format(-123456);
+  assertEquals('-1,23,456', str);
+  str = fmt.format(-1234567);
+  assertEquals('-12,34,567', str);
+  str = fmt.format(-12345678);
+  assertEquals('-1,23,45,678', str);
+  str = fmt.format(-123456789);
+  assertEquals('-12,34,56,789', str);
+  str = fmt.format(-1234567890);
+  assertEquals('-1,23,45,67,890', str);
+}
+
+function testUnknownNumberGroupings() {
+  // Test for any future unknown grouping format in addition to India
+  var fmt = new goog.i18n.NumberFormat('#,####,##,###');
+  var str = fmt.format(1);
+  assertEquals('1', str);
+  str = fmt.format(12);
+  assertEquals('12', str);
+  str = fmt.format(123);
+  assertEquals('123', str);
+  str = fmt.format(1234);
+  assertEquals('1,234', str);
+  str = fmt.format(12345);
+  assertEquals('12,345', str);
+  str = fmt.format(123456);
+  assertEquals('1,23,456', str);
+  str = fmt.format(1234567);
+  assertEquals('12,34,567', str);
+  str = fmt.format(12345678);
+  assertEquals('123,45,678', str);
+  str = fmt.format(123456789);
+  assertEquals('1234,56,789', str);
+  str = fmt.format(1234567890);
+  assertEquals('1,2345,67,890', str);
+  str = fmt.format(11234567890);
+  assertEquals('11,2345,67,890', str);
+  str = fmt.format(111234567890);
+  assertEquals('111,2345,67,890', str);
+  str = fmt.format(1111234567890);
+  assertEquals('1111,2345,67,890', str);
+  str = fmt.format(11111234567890);
+  assertEquals('1,1111,2345,67,890', str);
+  str = fmt.format(0);
+  assertEquals('0', str);
+  str = fmt.format(-1);
+  assertEquals('-1', str);
+  str = fmt.format(-12);
+  assertEquals('-12', str);
+  str = fmt.format(-123);
+  assertEquals('-123', str);
+  str = fmt.format(-1234);
+  assertEquals('-1,234', str);
+  str = fmt.format(-12345);
+  assertEquals('-12,345', str);
+  str = fmt.format(-123456);
+  assertEquals('-1,23,456', str);
+  str = fmt.format(-1234567);
+  assertEquals('-12,34,567', str);
+  str = fmt.format(-12345678);
+  assertEquals('-123,45,678', str);
+  str = fmt.format(-123456789);
+  assertEquals('-1234,56,789', str);
+  str = fmt.format(-1234567890);
+  assertEquals('-1,2345,67,890', str);
+  str = fmt.format(-11234567890);
+  assertEquals('-11,2345,67,890', str);
+  str = fmt.format(-111234567890);
+  assertEquals('-111,2345,67,890', str);
+  str = fmt.format(-1111234567890);
+  assertEquals('-1111,2345,67,890', str);
+  str = fmt.format(-11111234567890);
+  assertEquals('-1,1111,2345,67,890', str);
+
+  fmt = new goog.i18n.NumberFormat('#,#,##,###,#');
+  str = fmt.format(1);
+  assertEquals('1', str);
+  str = fmt.format(12);
+  assertEquals('1,2', str);
+  str = fmt.format(123);
+  assertEquals('12,3', str);
+  str = fmt.format(1234);
+  assertEquals('123,4', str);
+  str = fmt.format(12345);
+  assertEquals('1,234,5', str);
+  str = fmt.format(123456);
+  assertEquals('12,345,6', str);
+  str = fmt.format(1234567);
+  assertEquals('1,23,456,7', str);
+  str = fmt.format(12345678);
+  assertEquals('1,2,34,567,8', str);
+  str = fmt.format(123456789);
+  assertEquals('1,2,3,45,678,9', str);
+  str = fmt.format(1234567890);
+  assertEquals('1,2,3,4,56,789,0', str);
+  str = fmt.format(0);
+  assertEquals('0', str);
+  str = fmt.format(-1);
+  assertEquals('-1', str);
+  str = fmt.format(-12);
+  assertEquals('-1,2', str);
+  str = fmt.format(-123);
+  assertEquals('-12,3', str);
+  str = fmt.format(-1234);
+  assertEquals('-123,4', str);
+  str = fmt.format(-12345);
+  assertEquals('-1,234,5', str);
+  str = fmt.format(-123456);
+  assertEquals('-12,345,6', str);
+  str = fmt.format(-1234567);
+  assertEquals('-1,23,456,7', str);
+  str = fmt.format(-12345678);
+  assertEquals('-1,2,34,567,8', str);
+  str = fmt.format(-123456789);
+  assertEquals('-1,2,3,45,678,9', str);
+  str = fmt.format(-1234567890);
+  assertEquals('-1,2,3,4,56,789,0', str);
 }
 
 function testPerMill() {
@@ -1019,7 +1173,7 @@ function testCompactWithBaseFormattingFrench() {
   // Switch to French.
   stubs.set(goog.i18n, 'NumberFormatSymbols', goog.i18n.NumberFormatSymbols_fr);
   stubs.set(goog.i18n, 'CompactNumberFormatSymbols',
-            goog.i18n.CompactNumberFormatSymbols_fr);
+      goog.i18n.CompactNumberFormatSymbols_fr);
 
   var fmt = new goog.i18n.NumberFormat(
       goog.i18n.NumberFormat.Format.COMPACT_SHORT);


### PR DESCRIPTION
Our Globalization Engineering team at PayPal found a bug that is affecting those in India. Since the number grouping "#,##,###" isn't supported, our team found it was necessary to put in a bit of time and development to support users in India. Please see <b>Indian comma placement</b> found under <a href="http://en.wikipedia.org/wiki/Indian_rupee">Wikipedia's Indian rupee</a>.

The pull request includes code development and tests that supports (1) the Indian comma placement for the number grouping "#,##,###"; and (2) other future number groupings. The hope for (2) is that regardless of how absurd the number grouping might turn out, it will be supported in Google Closure.

Please contact me, <b>John Vu</b> at <a href="mailto:jovu@paypal.com">jovu@paypal.com</a>, if you have any questions.

P.S. This is my first time contributing to an open-source project so please let me know if there's anything else I should do aside from your <a href="https://github.com/google/closure-library/blob/master/CONTRIBUTING">guidelines for contributing</a>.