### PR TITLE
Use changedTouches instead of targetTouches in style.getClientPosition

### DIFF
--- a/closure/goog/style/style.js
+++ b/closure/goog/style/style.js
@@ -842,11 +842,10 @@ goog.style.getClientPosition = function(el) {
     var be = /** @type {!goog.events.BrowserEvent} */ (el);
     var targetEvent = el;
 
-    if (el.targetTouches && el.targetTouches.length) {
-      targetEvent = el.targetTouches[0];
-    } else if (isAbstractedEvent && be.getBrowserEvent().targetTouches &&
-        be.getBrowserEvent().targetTouches.length) {
-      targetEvent = be.getBrowserEvent().targetTouches[0];
+    if (el.changedTouches) {
+      targetEvent = el.changedTouches[0];
+    } else if (isAbstractedEvent && be.getBrowserEvent().changedTouches) {
+      targetEvent = be.getBrowserEvent().changedTouches[0];
     }
 
     return new goog.math.Coordinate(

--- a/closure/goog/style/style_test.js
+++ b/closure/goog/style/style_test.js
@@ -414,6 +414,10 @@ function testGetClientPositionEvent() {
 function testGetClientPositionTouchEvent() {
   var mockTouchEvent = {};
 
+  mockTouchEvent.changedTouches = [{}];
+  mockTouchEvent.changedTouches[0].clientX = 100;
+  mockTouchEvent.changedTouches[0].clientY = 200;
+
   mockTouchEvent.targetTouches = [{}];
   mockTouchEvent.targetTouches[0].clientX = 100;
   mockTouchEvent.targetTouches[0].clientY = 200;
@@ -430,11 +434,12 @@ function testGetClientPositionTouchEvent() {
 function testGetClientPositionEmptyTouchList() {
   var mockTouchEvent = {};
 
-  mockTouchEvent.clientX = 100;
-  mockTouchEvent.clientY = 200;
-
   mockTouchEvent.targetTouches = [];
   mockTouchEvent.touches = [];
+
+  mockTouchEvent.changedTouches = [{}];
+  mockTouchEvent.changedTouches[0].clientX = 100;
+  mockTouchEvent.changedTouches[0].clientY = 200;
 
   var pos = goog.style.getClientPosition(mockTouchEvent);
   assertEquals(100, pos.x);
@@ -444,6 +449,9 @@ function testGetClientPositionEmptyTouchList() {
 function testGetClientPositionAbstractedTouchEvent() {
   var e = new goog.events.BrowserEvent();
   e.event_ = {};
+  e.event_.changedTouches = [{}];
+  e.event_.changedTouches[0].clientX = 100;
+  e.event_.changedTouches[0].clientY = 200;
   e.event_.touches = [{}];
   e.event_.touches[0].clientX = 100;
   e.event_.touches[0].clientY = 200;


### PR DESCRIPTION
`targetTouches` is not defined for `touchend` or `touchcancel` events. `changedTouches` is always defined.

With the current implementation (after 116609a6de5a687a85299f3feeb6e044efa0d1a5) the position is always `[0, 0]` 

closes #41