### PR TITLE
Don't repeat template jsdoc tag

### DIFF
--- a/closure/goog/array/array.js
+++ b/closure/goog/array/array.js
@@ -1192,8 +1192,7 @@ goog.array.stableSort = function(arr, opt_compareFn) {
  *     and return a negative number, zero, or a positive number depending on
  *     whether the first argument is less than, equal to, or greater than the
  *     second.
- * @template T
- * @template K
+ * @template T,K
  */
 goog.array.sortByKey = function(arr, keyFn, opt_compareFn) {
   var keyCompareFn = opt_compareFn || goog.array.defaultCompare;


### PR DESCRIPTION
Error reported by the compiler:

```
ERR! compile closure/goog/array/array.js:1196: ERROR - Bad type annotation. @template tag at most once
ERR! compile  * @template K
ERR! compile               ^
ERR! compile 
ERR! compile 
ERR! compile 1 error(s), 0 warning(s)
ERR! compile 
ERR! Process exited with non-zero status, see log for more detail: 1 
```
