### PR TITLE
fix(i18n): es_US Number Group and Decimal Separator

### DIFF
--- a/closure/goog/i18n/numberformatsymbolsext.js
+++ b/closure/goog/i18n/numberformatsymbolsext.js
@@ -4371,8 +4371,8 @@ goog.i18n.NumberFormatSymbols_es_SV = {
  * @enum {string}
  */
 goog.i18n.NumberFormatSymbols_es_US = {
-  DECIMAL_SEP: ',',
-  GROUP_SEP: '.',
+  DECIMAL_SEP: '.',
+  GROUP_SEP: ',',
   PERCENT: '%',
   ZERO_DIGIT: '0',
   PLUS_SIGN: '+',


### PR DESCRIPTION
Corrects number formatting for the es_US locale.

Closes #348