### PR TITLE
Made _GetInputByPath in closurebuilder.py use os.path.realpath.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@
 # Name or Organization <email address>
 
 Google Inc.
+Stellar Science Ltd.
 Mohamed Mansour <hello@mohamedmansour.com>
 Bjorn Tipling <bjorn.tipling@gmail.com>
 SameGoal LLC <help@samegoal.com>

--- a/closure/bin/build/closurebuilder.py
+++ b/closure/bin/build/closurebuilder.py
@@ -122,11 +122,11 @@ def _GetInputByPath(path, sources):
 
   Returns:
     The source from sources identified by path, if found.  Converts to
-    absolute paths for comparison.
+    real paths for comparison.
   """
   for js_source in sources:
-    # Convert both to absolute paths for comparison.
-    if os.path.abspath(path) == os.path.abspath(js_source.GetPath()):
+    # Convert both to real paths for comparison.
+    if os.path.realpath(path) == os.path.realpath(js_source.GetPath()):
       return js_source
 
 


### PR DESCRIPTION
A problem occured if 'closurebuilder.py' was run with relative path inputs
and the sources were absolute paths with symlinks within. 'os.path.abspath'
always resolves symlinks in the stem it adds to a relative path even though
it doesn't ever resolve symlinks for absolute paths.

The solution was to use 'os.path.realpath' instead which resolves all
embedded symlinks, providing an apples-to-apples comparison.