### PR TITLE
Use nodejs vm module instead of undocumented internal API call.

### DIFF
--- a/closure/goog/bootstrap/nodejs.js
+++ b/closure/goog/bootstrap/nodejs.js
@@ -42,6 +42,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var vm = require('vm');
 
 
 /**
@@ -66,7 +67,7 @@ global.CLOSURE_IMPORT_SCRIPT = function(src) {
 
 // Declared here so it can be used to require base.js
 function nodeGlobalRequire(file) {
-  process.binding('evals').NodeScript.runInThisContext.call(
+  vm.Script.runInThisContext.call(
       global, fs.readFileSync(file), file);
 }
 


### PR DESCRIPTION
It's also not available anymore on unstable (`0.11`).

For reference:
[utils: do not use internal Node API](https://github.com/caolan/nodeunit/commit/5ba1a94e92339ecdca322465abd741fb82974a40)