### PR TITLE
XhrIo: goog.base to the event listener constructor

### DIFF
--- a/closure/goog/net/xhrio.js
+++ b/closure/goog/net/xhrio.js
@@ -71,7 +71,8 @@ goog.forwardDeclare('goog.Uri');
  */
 goog.net.XhrIo = function(opt_xmlHttpFactory) {
   goog.net.XhrIo.base(this, 'constructor');
-
+  goog.base(this);
+  
   /**
    * Map of default headers to add to every request, use:
    * XhrIo.headers.set(name, value)


### PR DESCRIPTION
Without this fix, I am unable to add event listeners to my goog.net.XhrIo object.