### PR TITLE
check existence of PercentLoaded function in other way

### DIFF
--- a/closure/goog/ui/media/flashobject.js
+++ b/closure/goog/ui/media/flashobject.js
@@ -623,7 +623,7 @@ goog.ui.media.FlashObject.prototype.isLoaded = function() {
     return true;
   }
 
-  if (this.getFlashElement().PercentLoaded &&
+  if ('PercentLoaded' in this.getFlashElement() &&
       this.getFlashElement().PercentLoaded() == 100) {
     return true;
   }

--- a/closure/goog/ui/media/flashobject_test.js
+++ b/closure/goog/ui/media/flashobject_test.js
@@ -163,6 +163,17 @@ function testThrowsRequiredVersionOfFlashNotAvailable() {
   flash.dispose();
 }
 
+function testIsLoadedForIE() {
+  control.$replayAll();
+
+  var flash = new goog.ui.media.FlashObject(FLASH_URL, domHelper);
+  flash.render();
+  assertNotThrows('isLoaded() should not throw exception', function(){
+  	flash.isLoaded();
+  })
+  flash.dispose();
+}
+
 function testIsLoadedAfterDispose() {
   control.$replayAll();
 

--- a/closure/goog/ui/media/flashobject_test.js
+++ b/closure/goog/ui/media/flashobject_test.js
@@ -168,8 +168,8 @@ function testIsLoadedForIE() {
 
   var flash = new goog.ui.media.FlashObject(FLASH_URL, domHelper);
   flash.render();
-  assertNotThrows('isLoaded() should not throw exception', function(){
-  	flash.isLoaded();
+  assertNotThrows('isLoaded() should not throw exception', function() {
+    flash.isLoaded();
   })
   flash.dispose();
 }


### PR DESCRIPTION
`this.getFlashElement().PercentLoaded` causes 'Object doesn't support this property or method' error in IE8.
`'PercentLoaded' in this.getFlashElement()` prevents this error.
Please find the below URL for the detail:
http://stackoverflow.com/questions/2192203/is-there-a-way-to-detect-flash-blockers#14649116

