### PR TITLE
Fix goog.json.serialize treatment of functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,5 @@ Ivan Kozik <ivan.kozik@gmail.com>
 Rich Dougherty <rich@rd.gen.nz>
 Chad Killingsworth <chadkillingsworth@missouristate.edu>
 Dan Pupius <dan.pupius@gmail.com>
+Paul Draper <paulddraper@gmail.com>
 

--- a/closure/goog/json/json.js
+++ b/closure/goog/json/json.js
@@ -216,6 +216,7 @@ goog.json.Serializer.prototype.serializeInternal = function(object, sb) {
     case 'boolean':
       sb.push(object);
       break;
+    case 'function':
     case 'undefined':
       sb.push('null');
       break;
@@ -232,10 +233,6 @@ goog.json.Serializer.prototype.serializeInternal = function(object, sb) {
       // as string, number and boolean? Most implementations do not and the
       // need is not very big
       this.serializeObject_(/** @type {Object} */ (object), sb);
-      break;
-    case 'function':
-      // Skip functions.
-      // TODO(user) Should we return something here?
       break;
     default:
       throw Error('Unknown type: ' + typeof object);
@@ -350,8 +347,6 @@ goog.json.Serializer.prototype.serializeObject_ = function(obj, sb) {
   for (var key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       var value = obj[key];
-      // Skip functions.
-      // TODO(ptucker) Should we return something for function properties?
       if (typeof value != 'function') {
         sb.push(sep);
         this.serializeString_(key, sb);

--- a/closure/goog/json/json_test.js
+++ b/closure/goog/json/json_test.js
@@ -107,6 +107,10 @@ function testArraySerialize() {
   assertNotEquals('{length:0}', goog.json.serialize({length: 0}), '[]');
 }
 
+function testFunctionSerialize() {
+  assertSerialize('null', function() {});
+}
+
 function testObjectSerialize_emptyObject() {
   assertSerialize('{}', {});
 }
@@ -125,6 +129,10 @@ function testObjectSerialize_whitespace() {
   assertSerialize('{" ":" "}', {' ': ' '});
 }
 
+function testUndefinedSerialize() {
+  assertSerialize('null', undefined);
+}
+
 function testSerializeSkipFunction() {
   var object = {
     s: 'string value',
@@ -132,7 +140,7 @@ function testSerializeSkipFunction() {
     i: 100,
     f: function() { var x = 'x'; }
   };
-  assertSerialize('', object.f);
+  assertSerialize('null', object.f);
   assertSerialize('{"s":"string value","b":true,"i":100}', object);
 }
 


### PR DESCRIPTION
`goog.json.serialize` sometimes returns invalid JSON.

```javascript
goog.json.serialize({foo:function(){}}) // returns '{}', good
goog.json.serialize([function(){},function(){}]) // returns '[,]', bad
```

While `'[,]'` is parseable by the lenient `goog.json.parse`, it is invalid JSON, and breaks for other parsers, e.g. `JSON.parse` or implementations in other languages.

After this change, the behavior is the same as the [ECMAScript standard](http://www.ecma-international.org/ecma-262/5.1/#sec-15.12.3) for `JSON.stringify` in these cases:

```javascript
goog.json.serialize({foo:function(){}}) // returns '{}'
goog.json.serialize([function(){},function(){}]) // returns '[null,null]'
```

---

There is additional nonstandard behavior, e.g. `goog.json.serialize(undefined)` is `''` rather than `undefined`. I would be happy to fix those as well, if we wanted it to adhere to that spec.

But at least after this change `goog.json.serialize` will output well-formed JSON.