### PR TITLE
BUGFIX: ComboBox.addItem should able added separator.

### DIFF
--- a/closure/goog/ui/combobox.js
+++ b/closure/goog/ui/combobox.js
@@ -321,7 +321,8 @@ goog.ui.ComboBox.prototype.dismiss = function() {
 
 /**
  * Adds a new menu item at the end of the menu.
- * @param {goog.ui.MenuItem} item Menu item to add to the menu.
+ * @param {goog.ui.MenuHeader|goog.ui.MenuItem|goog.ui.MenuSeparator} item Menu
+ *     item to add to the menu.
  */
 goog.ui.ComboBox.prototype.addItem = function(item) {
   this.menu_.addChild(item, true);


### PR DESCRIPTION
When compiling with Closure Compiler, it warning that `goog.ui.ComboBox`
can not allow codes like that:

``` JavaScript
var combobox = new goog.ui.ComboBox();
combobox.addItem(new goog.ui.MenuSeparator());
```

Codes like that should works, but compiler can not passed. So I modified
the annotation and make it works.
