### PR TITLE
Fix of rendering the "history_state" hidden input field in IE9

### DIFF
--- a/closure/goog/history/history.js
+++ b/closure/goog/history/history.js
@@ -234,7 +234,10 @@ goog.History = function(opt_invisible, opt_blankPageUrl, opt_input,
     input = opt_input;
   } else {
     var inputId = 'history_state' + goog.History.historyCount_;
-    input = goog.dom.createDom('input', { 'type': 'text', 'name': inputId, 'id': inputId, 'style': 'display:none'})
+    input = goog.dom.createDom('input', { 'type': 'text', 
+                                          'name': inputId, 
+                                          'id': inputId, 
+                                          'style': 'display:none'});
     document.body.appendChild(input);
   }
 


### PR DESCRIPTION
How it's looks before fix:
![ie9_-_win7](https://cloud.githubusercontent.com/assets/1370537/5156374/76310646-72c7-11e4-9ccc-c81ee0cd27f6.png)
