### PR TITLE
fix year char count test

### DIFF
--- a/closure/goog/i18n/datetimeparse.js
+++ b/closure/goog/i18n/datetimeparse.js
@@ -615,6 +615,8 @@ goog.i18n.DateTimeParse.prototype.subParseYear_ =
   // only if 2 digit was actually parsed, and pattern say it has 2 digit.
   if (!ch && pos[0] - start == 2 && part.count == 2) {
     cal.setTwoDigitYear_(value);
+  } else if(part.count!=value.toString().length){
+    return false;
   } else {
     cal.year = value;
   }


### PR DESCRIPTION
A fix for https://github.com/google/closure-library/issues/384

```
var date = new Date();
var p = new goog.i18n.DateTimeParse("MM'/'dd'/'yyyy"); // notice that we expect a 4-digit year
var res = p.strictParse("01/01/01", date); //  expected 0, but got 8
```
