### PR TITLE
Added lacking requirement

### DIFF
--- a/closure/goog/db/objectstore.js
+++ b/closure/goog/db/objectstore.js
@@ -24,6 +24,7 @@ goog.require('goog.async.Deferred');
 goog.require('goog.db.Cursor');
 goog.require('goog.db.Error');
 goog.require('goog.db.Index');
+goog.require('goog.db.KeyRange');
 goog.require('goog.debug');
 goog.require('goog.events');
 


### PR DESCRIPTION
goog.db.ObjectStore uses goog.db.KeyRange but is not required using goog.require().
