### PR TITLE
patching goog.array.reduce per issue 352

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,5 @@ Ivan Kozik <ivan.kozik@gmail.com>
 Rich Dougherty <rich@rd.gen.nz>
 Chad Killingsworth <chadkillingsworth@missouristate.edu>
 Dan Pupius <dan.pupius@gmail.com>
+Mike Dunn <dunn74@gmail.com>
 

--- a/closure/goog/array/array.js
+++ b/closure/goog/array/array.js
@@ -348,10 +348,14 @@ goog.array.reduce = goog.NATIVE_ARRAY_PROTOTYPES &&
                      goog.array.ARRAY_PROTOTYPE_.reduce) ?
     function(arr, f, val, opt_obj) {
       goog.asserts.assert(arr.length != null);
-      if (opt_obj) {
-        f = goog.bind(f, opt_obj);
+      var params = [];
+      for(var i = 1, l = arguments.length; i < l; i++){
+        params.push(arguments[i]);
       }
-      return goog.array.ARRAY_PROTOTYPE_.reduce.call(arr, f, val);
+      if (opt_obj) {
+        params[0] = goog.bind(f, opt_obj);
+      }
+      return goog.array.ARRAY_PROTOTYPE_.reduce.apply(arr, params);
     } :
     function(arr, f, val, opt_obj) {
       var rval = val;

--- a/closure/goog/array/array_test.js
+++ b/closure/goog/array/array_test.js
@@ -280,6 +280,12 @@ function testArrayReduceOmitDeleted() {
   assertEquals(2, goog.array.reduce(a, scope.testFn, 0, scope));
 }
 
+function testArrayReducePreviousValuePatch(){
+  assertEquals(3, goog.array.reduce([1,2], function(p, c){
+    return p + c;
+  }));
+}
+
 function testArrayReduceRight() {
   var a = [0, 1, 2, 3, 4];
   assertEquals('43210', goog.array.reduceRight(a, function(rval, val, i, arr) {


### PR DESCRIPTION
This commit patches the bug in `goog.array.reduce` that fails to set the previous argument if `initialValue` is not provided.

Rather than testing `undefined`, as initially proposed in the issue comments, reconstruct the arguments and use the `array.prototype.apply` method to correctly determine if the optional arguments were passed.

Unit test provided.

Fixes issue #352 