### PR TITLE
Allow setting CLOSURE_BASE_PATH to the empty string

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -869,7 +869,7 @@ if (goog.DEPENDENCIES_ENABLED) {
    * @private
    */
   goog.findBasePath_ = function() {
-    if (goog.global.CLOSURE_BASE_PATH) {
+    if (goog.isDef(goog.global.CLOSURE_BASE_PATH)) {
       goog.basePath = goog.global.CLOSURE_BASE_PATH;
       return;
     } else if (!goog.inHtmlDocument_()) {


### PR DESCRIPTION
Currently, if `CLOSURE_BASE_PATH` is set to the empty string then it is considered as `undefined` and ignored by the `goog.findBasePath_` function. This PR fixes the problem by using the `goog.isDef` function for testing whether `CLOSURE_BASE_PATH` was set by the user.