### PR TITLE
Fix for early cancel in goog.fx.Dragger

### DIFF
--- a/closure/goog/fx/dragger.js
+++ b/closure/goog/fx/dragger.js
@@ -464,7 +464,8 @@ goog.fx.Dragger.prototype.startDrag = function(e) {
 
     this.mouseDownTime_ = goog.now();
   } else {
-    this.dispatchEvent(goog.fx.Dragger.EventType.EARLY_CANCEL);
+    this.dragging_ = false;
+    this.endDrag(e);
   }
 };
 


### PR DESCRIPTION
An early cancel is triggered on the second drag start unless we set `this.dragging_ = false` after a first early cancel has occurred. Can someone please give their 2 cents on whether this is an appropriate fix or if I'm missing something?