### PR TITLE
Fixes #422 by getting scrollTop from document.documentElement before document.body

### DIFF
--- a/closure/goog/dom/dom.js
+++ b/closure/goog/dom/dom.js
@@ -607,7 +607,8 @@ goog.dom.getDocumentScroll_ = function(doc) {
     // The keyboard on IE10 touch devices shifts the page using the pageYOffset
     // without modifying scrollTop. For this case, we want the body scroll
     // offsets.
-    return new goog.math.Coordinate(el.scrollLeft, el.scrollTop);
+    return new goog.math.Coordinate(el.scrollLeft, goog.userAgent.MOBILE &&
+        doc.documentElement && doc.documentElement.scrollTop || el.scrollTop);
   }
   return new goog.math.Coordinate(win.pageXOffset || el.scrollLeft,
       win.pageYOffset || el.scrollTop);


### PR DESCRIPTION
In IE11 on Windows Phone `document.body.scrollTop` is always 0 when running in HTML5 Doctype. However, `document.documentElement.scrollTop` is updated correctly when scrolling the page vertically.

Fixes #422.