### PR TITLE
Do not rely on targetTouches for determining "relevant" touch

### DIFF
--- a/closure/goog/events/browserevent.js
+++ b/closure/goog/events/browserevent.js
@@ -223,8 +223,19 @@ goog.events.BrowserEvent.IEButtonMap = [
 goog.events.BrowserEvent.prototype.init = function(e, opt_currentTarget) {
   var type = this.type = e.type;
 
+  /** @type {Touch} */
+  var relevantTouch = null;
+  if (type == goog.events.EventType.TOUCHSTART ||
+      type == goog.events.EventType.TOUCHMOVE) {
+    relevantTouch = e.targetTouches[0];
+  } else if (type == goog.events.EventType.TOUCHEND ||
+             type == goog.events.EventType.TOUCHCANCEL) {
+    relevantTouch = e.changedTouches[0];
+  }
+
   // TODO(nicksantos): Change this.target to type EventTarget.
-  this.target = /** @type {Node} */ (e.target) || e.srcElement;
+  this.target = goog.isNull(relevantTouch) ?
+      /** @type {Node} */ (e.target) || e.srcElement : relevantTouch.target;
 
   // TODO(nicksantos): Change this.currentTarget to type EventTarget.
   this.currentTarget = /** @type {Node} */ (opt_currentTarget);
@@ -250,17 +261,25 @@ goog.events.BrowserEvent.prototype.init = function(e, opt_currentTarget) {
 
   this.relatedTarget = relatedTarget;
 
-  // Webkit emits a lame warning whenever layerX/layerY is accessed.
-  // http://code.google.com/p/chromium/issues/detail?id=101733
-  this.offsetX = (goog.userAgent.WEBKIT || e.offsetX !== undefined) ?
-      e.offsetX : e.layerX;
-  this.offsetY = (goog.userAgent.WEBKIT || e.offsetY !== undefined) ?
-      e.offsetY : e.layerY;
-
-  this.clientX = e.clientX !== undefined ? e.clientX : e.pageX;
-  this.clientY = e.clientY !== undefined ? e.clientY : e.pageY;
-  this.screenX = e.screenX || 0;
-  this.screenY = e.screenY || 0;
+  if (!goog.isNull(relevantTouch)) {
+    this.clientX = relevantTouch.clientX !== undefined ?
+        relevantTouch.clientX : relevantTouch.pageX;
+    this.clientY = relevantTouch.clientY !== undefined ?
+        relevantTouch.clientY : relevantTouch.pageY;
+    this.screenX = relevantTouch.screenX || 0;
+    this.screenY = relevantTouch.screenY || 0;
+  } else {
+    // Webkit emits a lame warning whenever layerX/layerY is accessed.
+    // http://code.google.com/p/chromium/issues/detail?id=101733
+    this.offsetX = (goog.userAgent.WEBKIT || e.offsetX !== undefined) ?
+        e.offsetX : e.layerX;
+    this.offsetY = (goog.userAgent.WEBKIT || e.offsetY !== undefined) ?
+        e.offsetY : e.layerY;
+    this.clientX = e.clientX !== undefined ? e.clientX : e.pageX;
+    this.clientY = e.clientY !== undefined ? e.clientY : e.pageY;
+    this.screenX = e.screenX || 0;
+    this.screenY = e.screenY || 0;
+  }
 
   this.button = e.button;
 

--- a/closure/goog/events/browserevent.js
+++ b/closure/goog/events/browserevent.js
@@ -223,19 +223,16 @@ goog.events.BrowserEvent.IEButtonMap = [
 goog.events.BrowserEvent.prototype.init = function(e, opt_currentTarget) {
   var type = this.type = e.type;
 
-  /** @type {Touch} */
-  var relevantTouch = null;
-  if (type == goog.events.EventType.TOUCHSTART ||
-      type == goog.events.EventType.TOUCHMOVE) {
-    relevantTouch = e.targetTouches[0];
-  } else if (type == goog.events.EventType.TOUCHEND ||
-             type == goog.events.EventType.TOUCHCANCEL) {
-    relevantTouch = e.changedTouches[0];
-  }
+  /**
+   * On touch devices use the first "changed touch" as the relevant touch.
+   * @type {Touch}
+   */
+  var relevantTouch = e.changedTouches ? e.changedTouches[0] : null;
 
   // TODO(nicksantos): Change this.target to type EventTarget.
   this.target = goog.isNull(relevantTouch) ?
-      /** @type {Node} */ (e.target) || e.srcElement : relevantTouch.target;
+      /** @type {Node} */ (e.target) || e.srcElement :
+      /** @type {Node} */ (relevantTouch.target);
 
   // TODO(nicksantos): Change this.currentTarget to type EventTarget.
   this.currentTarget = /** @type {Node} */ (opt_currentTarget);

--- a/closure/goog/events/browserevent_test.js
+++ b/closure/goog/events/browserevent_test.js
@@ -17,6 +17,7 @@ goog.setTestOnly('goog.events.BrowserEventTest');
 
 goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.BrowserFeature');
+goog.require('goog.math.Coordinate');
 goog.require('goog.testing.PropertyReplacer');
 goog.require('goog.testing.jsunit');
 goog.require('goog.userAgent');
@@ -68,19 +69,19 @@ function testDefaultPrevented() {
 function testIsButtonIe() {
   stubs.set(goog.events.BrowserFeature, 'HAS_W3C_BUTTON', false);
   assertIsButton(
-      createBrowserEvent('mousedown', 1),
+      createMouseEvent('mousedown', 1),
       Button.LEFT,
       true);
   assertIsButton(
-      createBrowserEvent('click', 0),
+      createMouseEvent('click', 0),
       Button.LEFT,
       true);
   assertIsButton(
-      createBrowserEvent('mousedown', 2),
+      createMouseEvent('mousedown', 2),
       Button.RIGHT,
       false);
   assertIsButton(
-      createBrowserEvent('mousedown', 4),
+      createMouseEvent('mousedown', 4),
       Button.MIDDLE,
       false);
 }
@@ -90,27 +91,27 @@ function testIsButtonWebkitMac() {
   stubs.set(goog.userAgent, 'WEBKIT', true);
   stubs.set(goog.userAgent, 'MAC', true);
   assertIsButton(
-      createBrowserEvent('mousedown', 0),
+      createMouseEvent('mousedown', 0),
       Button.LEFT,
       true);
   assertIsButton(
-      createBrowserEvent('mousedown', 0, true),
+      createMouseEvent('mousedown', 0, true),
       Button.LEFT,
       false);
   assertIsButton(
-      createBrowserEvent('mousedown', 2),
+      createMouseEvent('mousedown', 2),
       Button.RIGHT,
       false);
   assertIsButton(
-      createBrowserEvent('mousedown', 2, true),
+      createMouseEvent('mousedown', 2, true),
       Button.RIGHT,
       false);
   assertIsButton(
-      createBrowserEvent('mousedown', 1),
+      createMouseEvent('mousedown', 1),
       Button.MIDDLE,
       false);
   assertIsButton(
-      createBrowserEvent('mousedown', 1, true),
+      createMouseEvent('mousedown', 1, true),
       Button.MIDDLE,
       false);
 }
@@ -120,20 +121,74 @@ function testIsButtonGecko() {
   stubs.set(goog.userAgent, 'GECKO', true);
   stubs.set(goog.userAgent, 'MAC', true);
   assertIsButton(
-      createBrowserEvent('mousedown', 0),
+      createMouseEvent('mousedown', 0),
       Button.LEFT,
       true);
   assertIsButton(
-      createBrowserEvent('mousedown', 2, true),
+      createMouseEvent('mousedown', 2, true),
       Button.RIGHT,
       false);
 }
 
-function createBrowserEvent(type, button, opt_ctrlKey) {
+function testTouchEventHandling() {
+  var clientCoords = new goog.math.Coordinate(5, 5);
+  var screenCoords = new goog.math.Coordinate(10, 10);
+  var target = document.body;
+  var touchStart = createTargetTouchEvent('touchstart', target, clientCoords,
+    screenCoords);
+  var touchMove = createTargetTouchEvent('touchmove', target, clientCoords,
+    screenCoords);
+  var touchEnd = createChangedTouchEvent('touchend', target, clientCoords,
+    screenCoords);
+  var touchCancel = createChangedTouchEvent('touchcancel', target,
+    clientCoords, screenCoords);
+
+  assertEquals(clientCoords.x, touchStart.clientX);
+  assertEquals(clientCoords.y, touchStart.clientY);
+  assertEquals(target, touchStart.target);
+
+  assertEquals(screenCoords.x, touchMove.screenX);
+  assertEquals(screenCoords.y, touchMove.screenY);
+
+  assertEquals(clientCoords.x, touchEnd.clientX);
+  assertEquals(clientCoords.y, touchEnd.clientY);
+
+  assertEquals(screenCoords.x, touchCancel.screenX);
+  assertEquals(screenCoords.y, touchCancel.screenY);
+  assertEquals(target, touchCancel.target);
+}
+
+function createMouseEvent(type, button, opt_ctrlKey) {
   return new goog.events.BrowserEvent({
     type: type,
     button: button,
     ctrlKey: !!opt_ctrlKey
+  });
+}
+
+function createTargetTouchEvent(type, target, clientCoords, screenCoords) {
+  return new goog.events.BrowserEvent({
+    type: type,
+    targetTouches: [{
+      target: target,
+      clientX: clientCoords.x,
+      clientY: clientCoords.y,
+      screenX: screenCoords.x,
+      screenY: screenCoords.y
+    }]
+  });
+}
+
+function createChangedTouchEvent(type, target, clientCoords, screenCoords) {
+  return new goog.events.BrowserEvent({
+    type: type,
+    changedTouches: [{
+      target: target,
+      clientX: clientCoords.x,
+      clientY: clientCoords.y,
+      screenX: screenCoords.x,
+      screenY: screenCoords.y
+    }]
   });
 }
 

--- a/closure/goog/events/browserevent_test.js
+++ b/closure/goog/events/browserevent_test.js
@@ -134,14 +134,14 @@ function testTouchEventHandling() {
   var clientCoords = new goog.math.Coordinate(5, 5);
   var screenCoords = new goog.math.Coordinate(10, 10);
   var target = document.body;
-  var touchStart = createTargetTouchEvent('touchstart', target, clientCoords,
+  var touchStart = createTouchEvent('touchstart', target, clientCoords,
     screenCoords);
-  var touchMove = createTargetTouchEvent('touchmove', target, clientCoords,
+  var touchMove = createTouchEvent('touchmove', target, clientCoords,
     screenCoords);
-  var touchEnd = createChangedTouchEvent('touchend', target, clientCoords,
+  var touchEnd = createTouchEvent('touchend', target, clientCoords,
     screenCoords);
-  var touchCancel = createChangedTouchEvent('touchcancel', target,
-    clientCoords, screenCoords);
+  var touchCancel = createTouchEvent('touchcancel', target, clientCoords,
+    screenCoords);
 
   assertEquals(clientCoords.x, touchStart.clientX);
   assertEquals(clientCoords.y, touchStart.clientY);
@@ -166,20 +166,7 @@ function createMouseEvent(type, button, opt_ctrlKey) {
   });
 }
 
-function createTargetTouchEvent(type, target, clientCoords, screenCoords) {
-  return new goog.events.BrowserEvent({
-    type: type,
-    targetTouches: [{
-      target: target,
-      clientX: clientCoords.x,
-      clientY: clientCoords.y,
-      screenX: screenCoords.x,
-      screenY: screenCoords.y
-    }]
-  });
-}
-
-function createChangedTouchEvent(type, target, clientCoords, screenCoords) {
+function createTouchEvent(type, target, clientCoords, screenCoords) {
   return new goog.events.BrowserEvent({
     type: type,
     changedTouches: [{

--- a/closure/goog/fx/dragger.js
+++ b/closure/goog/fx/dragger.js
@@ -428,7 +428,6 @@ goog.fx.Dragger.prototype.startDrag = function(e) {
 
   if (this.enabled_ && !this.dragging_ &&
       (!isMouseDown || e.isMouseActionButton())) {
-    this.maybeReinitTouchEvent_(e);
     if (this.hysteresisDistanceSquared_ == 0) {
       if (this.fireDragStart_(e)) {
         this.dragging_ = true;
@@ -539,7 +538,6 @@ goog.fx.Dragger.prototype.endDrag = function(e, opt_dragCanceled) {
   this.cleanUpAfterDragging_();
 
   if (this.dragging_) {
-    this.maybeReinitTouchEvent_(e);
     this.dragging_ = false;
 
     var x = this.limitX(this.deltaX);
@@ -565,32 +563,12 @@ goog.fx.Dragger.prototype.endDragCancel = function(e) {
 
 
 /**
- * Re-initializes the event with the first target touch event or, in the case
- * of a stop event, the last changed touch.
- * @param {goog.events.BrowserEvent} e A TOUCH... event.
- * @private
- */
-goog.fx.Dragger.prototype.maybeReinitTouchEvent_ = function(e) {
-  var type = e.type;
-
-  if (type == goog.events.EventType.TOUCHSTART ||
-      type == goog.events.EventType.TOUCHMOVE) {
-    e.init(e.getBrowserEvent().targetTouches[0], e.currentTarget);
-  } else if (type == goog.events.EventType.TOUCHEND ||
-             type == goog.events.EventType.TOUCHCANCEL) {
-    e.init(e.getBrowserEvent().changedTouches[0], e.currentTarget);
-  }
-};
-
-
-/**
  * Event handler that is used on mouse / touch move to update the drag
  * @param {goog.events.BrowserEvent} e Event object.
  * @private
  */
 goog.fx.Dragger.prototype.handleMove_ = function(e) {
   if (this.enabled_) {
-    this.maybeReinitTouchEvent_(e);
     // dx in right-to-left cases is relative to the right.
     var sign = this.useRightPositioningForRtl_ &&
         this.isRightToLeft_() ? -1 : 1;

--- a/closure/goog/style/style.js
+++ b/closure/goog/style/style.js
@@ -836,7 +836,8 @@ goog.style.getClientPositionForElement_ = function(el) {
 
 /**
  * Returns the position of the event or the element's border box relative to
- * the client viewport.
+ * the client viewport. If an event is passed, and if this event is a "touch"
+ * event, then the position of the first changedTouches will be returned.
  * @param {Element|Event|goog.events.Event} el Element or a mouse / touch event.
  * @return {!goog.math.Coordinate} The position.
  */
@@ -846,17 +847,7 @@ goog.style.getClientPosition = function(el) {
     return goog.style.getClientPositionForElement_(
         /** @type {!Element} */ (el));
   } else {
-    var isAbstractedEvent = goog.isFunction(el.getBrowserEvent);
-    var be = /** @type {!goog.events.BrowserEvent} */ (el);
-    var targetEvent = el;
-
-    if (el.targetTouches && el.targetTouches.length) {
-      targetEvent = el.targetTouches[0];
-    } else if (isAbstractedEvent && be.getBrowserEvent().targetTouches &&
-        be.getBrowserEvent().targetTouches.length) {
-      targetEvent = be.getBrowserEvent().targetTouches[0];
-    }
-
+    var targetEvent = el.changedTouches ? el.changedTouches[0] : el;
     return new goog.math.Coordinate(
         targetEvent.clientX,
         targetEvent.clientY);

--- a/closure/goog/style/style_test.js
+++ b/closure/goog/style/style_test.js
@@ -411,14 +411,9 @@ function testGetClientPositionEvent() {
 
 function testGetClientPositionTouchEvent() {
   var mockTouchEvent = {};
-
-  mockTouchEvent.targetTouches = [{}];
-  mockTouchEvent.targetTouches[0].clientX = 100;
-  mockTouchEvent.targetTouches[0].clientY = 200;
-
-  mockTouchEvent.touches = [{}];
-  mockTouchEvent.touches[0].clientX = 100;
-  mockTouchEvent.touches[0].clientY = 200;
+  mockTouchEvent.changedTouches = [{}];
+  mockTouchEvent.changedTouches[0].clientX = 100;
+  mockTouchEvent.changedTouches[0].clientY = 200;
 
   var pos = goog.style.getClientPosition(mockTouchEvent);
   assertEquals(100, pos.x);
@@ -428,11 +423,11 @@ function testGetClientPositionTouchEvent() {
 function testGetClientPositionEmptyTouchList() {
   var mockTouchEvent = {};
 
-  mockTouchEvent.clientX = 100;
-  mockTouchEvent.clientY = 200;
-
-  mockTouchEvent.targetTouches = [];
   mockTouchEvent.touches = [];
+
+  mockTouchEvent.changedTouches = [{}];
+  mockTouchEvent.changedTouches[0].clientX = 100;
+  mockTouchEvent.changedTouches[0].clientY = 200;
 
   var pos = goog.style.getClientPosition(mockTouchEvent);
   assertEquals(100, pos.x);
@@ -440,14 +435,13 @@ function testGetClientPositionEmptyTouchList() {
 }
 
 function testGetClientPositionAbstractedTouchEvent() {
-  var e = new goog.events.BrowserEvent();
-  e.event_ = {};
-  e.event_.touches = [{}];
-  e.event_.touches[0].clientX = 100;
-  e.event_.touches[0].clientY = 200;
-  e.event_.targetTouches = [{}];
-  e.event_.targetTouches[0].clientX = 100;
-  e.event_.targetTouches[0].clientY = 200;
+  var mockTouchEvent = {};
+  mockTouchEvent.changedTouches = [{}];
+  mockTouchEvent.changedTouches[0].clientX = 100;
+  mockTouchEvent.changedTouches[0].clientY = 200;
+
+  var e = new goog.events.BrowserEvent(mockTouchEvent);
+
   var pos = goog.style.getClientPosition(e);
   assertEquals(100, pos.x);
   assertEquals(200, pos.y);


### PR DESCRIPTION
[`goog.events.BrowserEvent#init`](https://github.com/google/closure-library/blob/bdf0ea0aa60038928c0aea154645e3f1bcbd393e/closure/goog/events/browserevent.js#L226-L234) and [`goog.style.getClientPosition`](https://github.com/google/closure-library/blob/bdf0ea0aa60038928c0aea154645e3f1bcbd393e/closure/goog/style/style.js#L848-L853) currently make the same mistake: they use `event.targetTouches[0]` as the "relevant" touch.

As [mdn](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/targetTouches) documents it, `targetTouches` includes « the Touch objects for touch points that are still in contact with the touch surface and whose touchstart event occurred inside the same target element as the current target element ». So if there are multiple touches on the surface `targetTouches[0]` may not be the touch that caused the current event to happen!

This pull request fixes both `goog.events.BrowserEvent#init` and `goog.style.getClientPosition` by relying on `changedTouches[0]` instead. [`changedTouches`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches) includes « the Touch objects for touch points that contributed to this touch event », so using `changedTouches[0]` rather than `targetTouches[0]` is more correct.

Please review.

Fixes #337.