### PR TITLE
Add package.json file to support NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "google-closure-library",
   "description": "Google's common JavaScript library",
-  "version": "20150126.0.0",
+  "version": "20150315.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/google/closure-library.git"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
   "name": "google-closure-library",
   "description": "Google's common JavaScript library",
-  "version": "1.0.0",
+  "version": "20150126.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/google/closure-library.git"
   },
+  "keywords": [
+    "javascript",
+    "library",
+    "goog",
+    "closure"
+  ],
   "author": "The Closure Library Authors",
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "google-closure-library",
+  "description": "Google's common JavaScript library",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/closure-library.git"
+  },
+  "author": "The Closure Library Authors",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/google/closure-library/issues"
+  },
+  "homepage": "https://developers.google.com/closure/library/"
+}


### PR DESCRIPTION
This commit adds a package.json file to the project to allow the Node Package Manager to utilize the project as a dependency. The package.json specifically sets the `private` option to `true` to prevent the project from being published to [npmjs.com](https://www.npmjs.com/). Rather, consumers should specify a git-commit URL for versioning. The `version` field is required by NPM.

