### PR TITLE
Update the CLOSURE_IMPORT_SCRIPT method

### DIFF
--- a/closure/goog/bootstrap/nodejs.js
+++ b/closure/goog/bootstrap/nodejs.js
@@ -60,7 +60,7 @@ global.goog = {};
 global.CLOSURE_IMPORT_SCRIPT = function(src) {
   // Sources are always expressed relative to closure's base.js, but
   // require() is always relative to the current source.
-  require('./../' + src);
+  require(path.resolve(__dirname + '/../', src));
   return true;
 };
 


### PR DESCRIPTION
I have accepted the CLA.

The proposed change will allow the use of absolute file paths passed as the 'src' parameter instead of only paths relative to the base.js file. This is handy when trying to separate out my dependency files into multiple packages.

I can now do something like this in my deps.js file.
goog.addDependency(__dirname + '/pbx/db/Connection.js', ['pbx.db.Connection'], [], false);
goog.addDependency(__dirname + '/pbx/db/DataGroup.js', ['pbx.db.DataGroup'], ['pbx.db.Connection', 'pbx.db.DataGroup'], false);