### PR TITLE
Cast goog.IS_OLD_IE_ value to boolean

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -909,8 +909,8 @@ if (goog.DEPENDENCIES_ENABLED) {
 
 
   /** @const @private {boolean} */
-  goog.IS_OLD_IE_ = !goog.global.atob && goog.global.document &&
-      goog.global.document.all;
+  goog.IS_OLD_IE_ = !!(!goog.global.atob && goog.global.document &&
+      goog.global.document.all);
 
 
   /**


### PR DESCRIPTION
Otherwise `goog.IS_OLD_IE_` is `goog.global.document.all`