### PR TITLE
closure: Fix uri query parameter encoding

### DIFF
--- a/closure/goog/uri/uri.js
+++ b/closure/goog/uri/uri.js
@@ -332,7 +332,7 @@ goog.Uri.prototype.resolve = function(relativeUri) {
   }
 
   if (overridden) {
-    absoluteUri.setQueryData(relativeUri.getDecodedQuery());
+    absoluteUri.setQueryData(relativeUri.getQueryData().clone());
   } else {
     overridden = relativeUri.hasFragment();
   }

--- a/closure/goog/uri/uri_test.js
+++ b/closure/goog/uri/uri_test.js
@@ -147,6 +147,10 @@ function testQueryResolution() {
   assertEquals('http://www.google.com/search?q=new%20search',
                goog.Uri.parse('http://www.google.com/search?q=old+search#hi').
                    resolve(goog.Uri.parse('?q=new%20search')).toString());
+
+  assertEquals('http://www.google.com/search?q=%26',
+               goog.Uri.parse('http://www.google.com/search').
+                   resolve(goog.Uri.parse('?q=%26')).toString());
 }
 
 function testFragmentResolution() {


### PR DESCRIPTION
This fixes handling of URIs with special characters. Without this patch, segment URIs such as e.g. http://example.com/0.webm?param=%26 may be translated to http://example.com/0.webm?param=&.

Fixed in shaka-player: https://github.com/google/shaka-player/pull/40