### PR TITLE
fixed jsdocs

### DIFF
--- a/closure/goog/date/date.js
+++ b/closure/goog/date/date.js
@@ -834,7 +834,7 @@ goog.date.Date.prototype.getFullYear = function() {
  * Alias for getFullYear.
  *
  * @return {number} The four digit year of date.
- * @see #getFullyear
+ * @see #getFullYear
  */
 goog.date.Date.prototype.getYear = function() {
   return this.getFullYear();

--- a/closure/goog/editor/range.js
+++ b/closure/goog/editor/range.js
@@ -80,7 +80,7 @@ goog.editor.range.narrow = function(range, el) {
  * Given a range, expand the range to include outer tags if the full contents of
  * those tags are entirely selected.  This essentially changes the dom position,
  * but not the visible position of the range.
- * Ex. <li>foo</li> if "foo" is selected, instead of returning start and end
+ * Ex. <code><li>foo</li></code> if "foo" is selected, instead of returning start and end
  * nodes as the foo text node, return the li.
  * @param {goog.dom.AbstractRange} range The range.
  * @param {Node=} opt_stopNode Optional node to stop expanding past.

--- a/closure/goog/format/htmlprettyprinter_test.js
+++ b/closure/goog/format/htmlprettyprinter_test.js
@@ -165,7 +165,7 @@ function testRegexMakesProgress() {
 
 
 /**
- * FF3.0 doesn't like \n between </li> and </ul>. See bug 1520665.
+ * FF3.0 doesn't like \n between <code></li></code> and <code></ul></code>. See bug 1520665.
  */
 function testLists() {
   var original = '<ul><li>one</li><ul><li>two</li></UL><li>three</li></ul>';

--- a/closure/goog/html/safestyle.js
+++ b/closure/goog/html/safestyle.js
@@ -42,7 +42,7 @@ goog.require('goog.string.TypedString');
  * is immutable; hence only a default instance corresponding to the empty string
  * can be obtained via constructor invocation.
  *
- * A SafeStyle's string representation ({@link #getSafeStyleString()}) can
+ * A SafeStyle's string representation ({@link #getTypedStringValue()}) can
  * safely:
  * <ul>
  *   <li>Be interpolated as the entire content of a *quoted* HTML style


### PR DESCRIPTION
The PR fixes some @code/@see tags in JSDoc that point to wrong methods and usage of HTML in JSDocs.