### PR TITLE
patching goog.array.reduce to conform to spec

### DIFF
--- a/closure/goog/array/array.js
+++ b/closure/goog/array/array.js
@@ -346,20 +346,33 @@ goog.array.map = goog.NATIVE_ARRAY_PROTOTYPES &&
 goog.array.reduce = goog.NATIVE_ARRAY_PROTOTYPES &&
                     (goog.array.ASSUME_NATIVE_FUNCTIONS ||
                      goog.array.ARRAY_PROTOTYPE_.reduce) ?
-    function(arr, f, val, opt_obj) {
-      goog.asserts.assert(arr.length != null);
-      if (opt_obj) {
-        f = goog.bind(f, opt_obj);
+  function(arr, f, val, opt_obj) {
+    goog.asserts.assert(arr.length != null);
+    var params = [];
+    for(var i = 1, l = arguments.length; i < l; i++){
+      params.push(arguments[i]);
+    }
+    if (opt_obj) {
+      params[0] = goog.bind(f, opt_obj);
+    }
+    return goog.array.ARRAY_PROTOTYPE_.reduce.apply(arr, params);
+  } :
+  function(arr, f, val, opt_obj) {
+    goog.asserts.assert(arr.length > 0);
+    var value, length = arr.length, i = 0;
+    if (arguments.length > 2) {
+      value = arguments[2];
+    } else {
+      value = arr[0];
+      i = 1;
+    }
+    for (; i < length; i++) {
+      if(i in arr){
+        value = f.call(opt_obj, value, arr[i], i, arr);
       }
-      return goog.array.ARRAY_PROTOTYPE_.reduce.call(arr, f, val);
-    } :
-    function(arr, f, val, opt_obj) {
-      var rval = val;
-      goog.array.forEach(arr, function(val, index) {
-        rval = f.call(opt_obj, rval, val, index, arr);
-      });
-      return rval;
-    };
+    }
+    return value;
+  };
 
 
 /**

--- a/closure/goog/array/array_test.js
+++ b/closure/goog/array/array_test.js
@@ -281,6 +281,12 @@ function testArrayReduceOmitDeleted() {
   assertEquals(2, goog.array.reduce(a, scope.testFn, 0, scope));
 }
 
+function testArrayReducePreviousValuePatch(){
+  assertEquals(3, goog.array.reduce([1,2], function(p, c){
+    return p + c;
+  }));
+}
+
 function testArrayReduceRight() {
   var a = [0, 1, 2, 3, 4];
   assertEquals('43210', goog.array.reduceRight(a, function(rval, val, i, arr) {


### PR DESCRIPTION
updating both prototypal and procedural versions per #352.  

unit test added.

maintains backward compatibility - all `goog.array` tests pass, tested in IE6, IE7, IE8, IE9, IE10, IE11, Chrome, FireFox, Safari, Opera.