### PR TITLE
goog.string.html errors in ECMASCRIPT5_STRICT

### DIFF
--- a/third_party/closure/goog/caja/string/html/htmlparser.js
+++ b/third_party/closure/goog/caja/string/html/htmlparser.js
@@ -68,7 +68,7 @@ goog.string.html.HtmlParser.Entities = {
   lt: '<',
   gt: '>',
   amp: '&',
-  nbsp: '\240',
+  nbsp: '\xA0',
   quot: '"',
   apos: '\''
 };
@@ -90,7 +90,7 @@ goog.string.html.HtmlParser.EFlags = {
 
 /**
  * A map of element to a bitmap of flags it has, used internally on the parser.
- * @type {Object}
+ * @type {Object<string, number>}
  */
 goog.string.html.HtmlParser.Elements = {
   'a': 0,
@@ -209,7 +209,6 @@ goog.string.html.HtmlParser.Elements = {
 /**
  * Regular expression that matches &s.
  * @type {RegExp}
- * @private
  */
 goog.string.html.HtmlParser.AMP_RE_ = /&/g;
 
@@ -226,7 +225,6 @@ goog.string.html.HtmlParser.LOOSE_AMP_RE_ =
 /**
  * Regular expression that matches <.
  * @type {RegExp}
- * @private
  */
 goog.string.html.HtmlParser.LT_RE_ = /</g;
 
@@ -234,7 +232,6 @@ goog.string.html.HtmlParser.LT_RE_ = /</g;
 /**
  * Regular expression that matches >.
  * @type {RegExp}
- * @private
  */
 goog.string.html.HtmlParser.GT_RE_ = />/g;
 
@@ -242,7 +239,6 @@ goog.string.html.HtmlParser.GT_RE_ = />/g;
 /**
  * Regular expression that matches ".
  * @type {RegExp}
- * @private
  */
 goog.string.html.HtmlParser.QUOTE_RE_ = /\"/g;
 
@@ -250,7 +246,6 @@ goog.string.html.HtmlParser.QUOTE_RE_ = /\"/g;
 /**
  * Regular expression that matches =.
  * @type {RegExp}
- * @private
  */
 goog.string.html.HtmlParser.EQUALS_RE_ = /=/g;
 

--- a/third_party/closure/goog/caja/string/html/htmlparser.js
+++ b/third_party/closure/goog/caja/string/html/htmlparser.js
@@ -209,6 +209,7 @@ goog.string.html.HtmlParser.Elements = {
 /**
  * Regular expression that matches &s.
  * @type {RegExp}
+ * @package
  */
 goog.string.html.HtmlParser.AMP_RE_ = /&/g;
 
@@ -216,7 +217,7 @@ goog.string.html.HtmlParser.AMP_RE_ = /&/g;
 /**
  * Regular expression that matches loose &s.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.LOOSE_AMP_RE_ =
     /&([^a-z#]|#(?:[^0-9x]|x(?:[^0-9a-f]|$)|$)|$)/gi;
@@ -225,6 +226,7 @@ goog.string.html.HtmlParser.LOOSE_AMP_RE_ =
 /**
  * Regular expression that matches <.
  * @type {RegExp}
+ * @package
  */
 goog.string.html.HtmlParser.LT_RE_ = /</g;
 
@@ -232,6 +234,7 @@ goog.string.html.HtmlParser.LT_RE_ = /</g;
 /**
  * Regular expression that matches >.
  * @type {RegExp}
+ * @package
  */
 goog.string.html.HtmlParser.GT_RE_ = />/g;
 
@@ -239,6 +242,7 @@ goog.string.html.HtmlParser.GT_RE_ = />/g;
 /**
  * Regular expression that matches ".
  * @type {RegExp}
+ * @package
  */
 goog.string.html.HtmlParser.QUOTE_RE_ = /\"/g;
 
@@ -246,6 +250,7 @@ goog.string.html.HtmlParser.QUOTE_RE_ = /\"/g;
 /**
  * Regular expression that matches =.
  * @type {RegExp}
+ * @package
  */
 goog.string.html.HtmlParser.EQUALS_RE_ = /=/g;
 
@@ -253,7 +258,7 @@ goog.string.html.HtmlParser.EQUALS_RE_ = /=/g;
 /**
  * Regular expression that matches null characters.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.NULL_RE_ = /\0/g;
 
@@ -261,7 +266,7 @@ goog.string.html.HtmlParser.NULL_RE_ = /\0/g;
 /**
  * Regular expression that matches entities.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.ENTITY_RE_ = /&(#\d+|#x[0-9A-Fa-f]+|\w+);/g;
 
@@ -269,7 +274,7 @@ goog.string.html.HtmlParser.ENTITY_RE_ = /&(#\d+|#x[0-9A-Fa-f]+|\w+);/g;
 /**
  * Regular expression that matches decimal numbers.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.DECIMAL_ESCAPE_RE_ = /^#(\d+)$/;
 
@@ -277,7 +282,7 @@ goog.string.html.HtmlParser.DECIMAL_ESCAPE_RE_ = /^#(\d+)$/;
 /**
  * Regular expression that matches hexadecimal numbers.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.HEX_ESCAPE_RE_ = /^#x([0-9A-Fa-f]+)$/;
 
@@ -285,7 +290,7 @@ goog.string.html.HtmlParser.HEX_ESCAPE_RE_ = /^#x([0-9A-Fa-f]+)$/;
 /**
  * Regular expression that matches the next token to be processed.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.INSIDE_TAG_TOKEN_ = new RegExp(
     // Don't capture space.
@@ -327,7 +332,7 @@ goog.string.html.HtmlParser.INSIDE_TAG_TOKEN_ = new RegExp(
  * Regular expression that matches the next token to be processed when we are
  * outside a tag.
  * @type {RegExp}
- * @private
+ * @package
  */
 goog.string.html.HtmlParser.OUTSIDE_TAG_TOKEN_ = new RegExp(
     '^(?:' +

--- a/third_party/closure/goog/caja/string/html/htmlsanitizer.js
+++ b/third_party/closure/goog/caja/string/html/htmlsanitizer.js
@@ -85,9 +85,9 @@ goog.string.html.htmlSanitize = function(
  *
  * @param {goog.string.StringBuffer} stringBuffer A string buffer, used to
  *     output the html as we sanitize it.
- * @param {?function(string):string} opt_urlPolicy An optional function to be
+ * @param {function(string):string=} opt_urlPolicy An optional function to be
  *     applied in URLs.
- * @param {?function(string):string} opt_nmTokenPolicy An optional function to
+ * @param {function(string):string=} opt_nmTokenPolicy An optional function to
  *     be applied in names.
  * @constructor
  * @extends {goog.string.html.HtmlSaxHandler}
@@ -120,14 +120,14 @@ goog.string.html.HtmlSanitizer = function(
 
   /**
    * A function to be applied to urls found on the parsing process.
-   * @type {?function(string):string}
+   * @type {function(string):string|undefined}
    * @private
    */
   this.urlPolicy_ = opt_urlPolicy;
 
   /**
    * A function to be applied to names fround on the parsing process.
-   * @type {?function(string):string}
+   * @type {function(string):string|undefined}
    * @private
    */
   this.nmTokenPolicy_ = opt_nmTokenPolicy;
@@ -548,7 +548,7 @@ goog.string.html.HtmlSanitizer.prototype.escapeAttrib_ = function(s) {
  * Sanitizes attributes found on html entities.
  * @param {string} tagName The name of the tag in which the {@code attribs} were
  *     found.
- * @param {Array.<?string>} attribs An array of attributes.
+ * @param {Array.<(?string|undefined)>} attribs An array of attributes.
  * @return {Array.<?string>} A sanitized version of the {@code attribs}.
  * @private
  */


### PR DESCRIPTION
When compiled with a language_in/out of ECMASCRIPT5_STRICT and with the ACCESS_CONTROLS warning guard, the caja libraries produce errors.