### PR TITLE
goog.module() can now be used in NodeJS projects

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -1344,6 +1344,31 @@ goog.normalizePath_ = function(path) {
 
 
 /**
+ * Loads file by synchronous XHR. Should not be used in production environments.
+ * @param {string} src Source URL.
+ * @returns {string} File contents.
+ * @private
+ */
+
+goog.loadFileSync_ = function(src) {
+  if (goog.global.CLOSURE_LOAD_FILE_SYNC) {
+    return goog.global.CLOSURE_LOAD_FILE_SYNC(src);
+  } else {
+    var xhr = new goog.global['XMLHttpRequest']();
+
+    /** @this {Object} */
+    xhr.onload = function() {
+      scriptText = this.responseText;
+    };
+    xhr.open('get', src, false);
+    xhr.send();
+
+    return xhr.responseText;
+  }
+};
+
+
+/**
  * Retrieve and execute a module.
  * @param {string} src Script source URL.
  * @private
@@ -1359,18 +1384,7 @@ goog.retrieveAndExecModule_ = function(src) {
     var importScript = goog.global.CLOSURE_IMPORT_SCRIPT ||
         goog.writeScriptTag_;
 
-    var scriptText = null;
-
-    var xhr = new goog.global['XMLHttpRequest']();
-
-    /** @this {Object} */
-    xhr.onload = function() {
-      scriptText = this.responseText;
-    };
-    xhr.open('get', src, false);
-    xhr.send();
-
-    scriptText = xhr.responseText;
+    var scriptText = goog.loadFileSync_(src);
 
     if (scriptText != null) {
       var execModuleScript = goog.wrapModule_(src, scriptText);

--- a/closure/goog/base_test.js
+++ b/closure/goog/base_test.js
@@ -1428,6 +1428,18 @@ function testGoogModuleGet() {
   assertEquals(earlyTestModuleGet, testModuleExports);
 }
 
+function testLoadFileSync() {
+  var fileContents = goog.loadFileSync_("deps.js");
+  assertTrue("goog.loadFileSync_ returns string", typeof fileContents === "string");
+  assertTrue("goog.loadFileSync_ string length > 0", fileContents.length > 0);
+
+  stubs.set(goog.global, 'CLOSURE_LOAD_FILE_SYNC', function(src) {
+    return "closure load file sync: "+src;
+  });
+
+  assertEquals("goog.CLOSURE_LOAD_FILE_SYNC override", goog.loadFileSync_("test url"), "closure load file sync: test url");
+}
+
 function testNormalizePath() {
   assertEquals('foo/path.js', goog.normalizePath_('./foo/./path.js'));
   assertEquals('foo/path.js', goog.normalizePath_('bar/../foo/path.js'));

--- a/closure/goog/bootstrap/nodejs.js
+++ b/closure/goog/bootstrap/nodejs.js
@@ -57,11 +57,27 @@ global.goog = {};
  * @param {string} src The script source.
  * @return {boolean} True if the script was imported, false otherwise.
  */
-global.CLOSURE_IMPORT_SCRIPT = function(src) {
+global.CLOSURE_IMPORT_SCRIPT = function(src, opt_sourceText) {
   // Sources are always expressed relative to closure's base.js, but
   // require() is always relative to the current source.
-  require('./../' + src);
+  if (opt_sourceText === undefined) {
+      require('./../' + src);
+  } else {
+      eval(opt_sourceText);
+  }
   return true;
+};
+
+
+/**
+ * Loads a file when using Closure's goog.require() API with goog.modules.
+ *
+ * @param {string} src The file source.
+ * @return {string} The file contents.
+ */
+
+global.CLOSURE_LOAD_FILE_SYNC = function(src) {
+  return fs.readFileSync(path.resolve(__dirname,'..', src), { encoding: "utf-8" });
 };
 
 


### PR DESCRIPTION
Added support for goog.module() in NodeJS projects, through the bootstrap/nodejs.js module.

`goog.module()` currently loads resources by synchronous XMLHttpRequest. This commit abstracts that into a new private function, `goog.loadFileSync_(src)`, which returns the loaded file and provides for an override hook, `goog.global.CLOSURE_LOAD_FILE_SYNC`.

bootstrap/nodejs.js now implements that override, and updates its `goog.writeScriptTag_()` override to support that function's new `goog.module()` behavior.