### PR TITLE
Fixes issue #427.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Chad Killingsworth <chadkillingsworth@missouristate.edu>
 Dan Pupius <dan.pupius@gmail.com>
 Mike Dunn <dunn74@gmail.com>
 Kengo Toda <skypencil@gmail.com>
+Remember The Milk Inc.

--- a/closure/goog/date/date.js
+++ b/closure/goog/date/date.js
@@ -243,7 +243,7 @@ goog.date.getWeekNumber = function(year, month, date, opt_weekDay,
   var d = new Date(year, month, date);
 
   // Default to Thursday for cut off as per ISO 8601.
-  var cutoff = opt_weekDay || goog.date.weekDay.THU;
+  var cutoff = goog.isDef(opt_weekDay) ? opt_weekDay : goog.date.weekDay.THU;
 
   // Default to Monday for first day of the week as per ISO 8601.
   var firstday = opt_firstDayOfWeek || goog.date.weekDay.MON;

--- a/closure/goog/date/date_test.js
+++ b/closure/goog/date/date_test.js
@@ -242,6 +242,8 @@ function testGetWeekNumber() {
                f(2007, goog.date.month.JAN, 1, goog.date.weekDay.MON));
   assertEquals('2007-01-01 is in week 1 (cutoff=Sunday)', 1,
                f(2007, goog.date.month.JAN, 1, goog.date.weekDay.SUN));
+  assertEquals('2015-01-01 is in week 52 of the previous year (cutoff=Monday)', 52,
+               f(2015, goog.date.month.JAN, 1, goog.date.weekDay.MON));
 
   // Tests for leap year 2000.
   assertEquals('2000-02-27 is in week 8', 8,


### PR DESCRIPTION
Cut off weekday bug in goog.date.getWeekNumber when it is 0
(goog.date.weekDay.MON).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/closure-library/460)
<!-- Reviewable:end -->
