### PR TITLE
Fix issue #51 for the new Opera browser (Blink engine).

### DIFF
--- a/closure/goog/events/keyhandler.js
+++ b/closure/goog/events/keyhandler.js
@@ -390,7 +390,7 @@ goog.events.KeyHandler.prototype.handleEvent = function(e) {
             be.charCode : 0;
 
   // Opera reports the keycode or the character code in the keyCode field.
-  } else if (goog.userAgent.OPERA) {
+  } else if (goog.userAgent.OPERA && !goog.userAgent.WEBKIT) {
     keyCode = this.keyCode_;
     charCode = goog.events.KeyCodes.isCharacterKey(keyCode) ?
         be.keyCode : 0;


### PR DESCRIPTION
Issue #51: goog.events.KeyHandler is not dispatching KEY event on arrow
keys in Opera

This fix ensures that any Opera browser running under the Blink engine
(identified as goog.userAgent.WEBKIT in Closure Library) will be handled
the same way as Chrome is handled by goog.events.KeyHandler#handleEvent.