### PR TITLE
Fix DST bug in goog.date.Date.

### DIFF
--- a/closure/goog/date/date.js
+++ b/closure/goog/date/date.js
@@ -765,10 +765,14 @@ goog.date.Date = function(opt_year, opt_month, opt_date) {
     this.maybeFixDst_(opt_year.getDate());
   } else {
     this.date = new Date(goog.now());
+
+    var expectedDate = this.date.getDate();
+
     this.date.setHours(0);
     this.date.setMinutes(0);
     this.date.setSeconds(0);
     this.date.setMilliseconds(0);
+    this.maybeFixDst_(expectedDate);
   }
 };
 


### PR DESCRIPTION
Although this is fixed in the current Google Chrome, it's still
reproducible in the newst Firefox (version 37.0.2).

See issue #34 for more details.