### PR TITLE
This PR fixes a 'Remove Formatting' bug in the Google Editor that causes problems with <p> -> <br> tag replacements. Also, when the Google Editor opens, the lower textarea loads with an &nbsp. This PR fixes that issue as well.

### DIFF
--- a/closure/goog/demos/editor/editor.html
+++ b/closure/goog/demos/editor/editor.html
@@ -133,7 +133,11 @@ hooked up to a toolbar.</p>
       updateFieldContents);
 
   myField.makeEditable();
-  updateFieldContents();
+
+  // Remove call to updateFieldContents() here because this function
+  // places an &nbsp in 'fieldContents' - the lower textarea in the
+  // editor.
+
   </script>
 </body>
 </html>

--- a/closure/goog/editor/plugins/removeformatting.js
+++ b/closure/goog/editor/plugins/removeformatting.js
@@ -651,8 +651,21 @@ goog.editor.plugins.RemoveFormatting.prototype.removeFormattingWorker_ =
           continue;
 
         case goog.dom.TagName.P:
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+
+		  // Make sure the "P" paragraph tag is not the first
+		  // node processed. This prevents an "extra" blank
+		  // line at the top of selected text that starts with
+		  // a paragraph tag. The "Set Field Contents" onclick
+		  // will rebalance all unmatched <p> and/or </p> tags,
+		  // but note that all empty <p></p> pairs will become
+		  // <br><br> in the assembled string. Maybe a future
+		  // enhancement could clean out those empty pairs at
+		  // some point in the function.
+
+		  if ((numNodesProcessed > 1) && (nodeName === "P")) {
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+		  }
           break;  // break (not continue) so that child nodes are processed.
 
         case goog.dom.TagName.BR:


### PR DESCRIPTION
This pull request fixes a bug in the Google Editor.

Steps to reproduce the bug:

1) Place text with &lt;p&gt;&lt;/p&gt; tags in the lower goog.editor textarea

&nbsp;&nbsp;ex: &lt;p&gt;First paragraph&lt;/p&gt;&lt;p&gt;second paragraph&lt;br&gt;second line&lt;/p&gt;&lt;br&gt;&lt;br&gt;&lt;p&gt;third paragraph&lt;br&gt;&lt;br&gt;&lt;br&gt;&lt;br&gt;third line&lt;/p&gt;&lt;br&gt;&lt;br&gt;&lt;p&gt;fourth line&lt;/p&gt;

2) Click 'Set Field Contents' to copy the text into the upper textarea (you might have problems doing this but eventually it will work)

3) In the upper textarea, highlight / select all the text and then click the 'Remove Formatting' button

'Remove Formatting' will not consistently / reliably replace the &lt;p&gt; tags with &lt;br&gt; tags. In this text sample, 'Remove Formatting' placed two &lt;br&gt; tags at the start of the text, for example.

This pull request fixes that bug.

Also, when the Google Editor opens, the lower textarea loads with an &nbsp. This PR fixes that issue as well.