### PR TITLE
This PR fixes issue #415: goog.ui.DatePicker allows selection of dates in other months when ShowOtherMonths is false.

### DIFF
--- a/closure/goog/editor/plugins/removeformatting.js
+++ b/closure/goog/editor/plugins/removeformatting.js
@@ -651,8 +651,21 @@ goog.editor.plugins.RemoveFormatting.prototype.removeFormattingWorker_ =
           continue;
 
         case goog.dom.TagName.P:
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+
+		  // Make sure the "P" paragraph tag is not the first
+		  // node processed. This prevents an "extra" blank
+		  // line at the top of selected text that starts with
+		  // a paragraph tag. The "Set Field Contents" onclick
+		  // will rebalance all unmatched <p> and/or </p> tags,
+		  // but note that all empty <p></p> pairs will become
+		  // <br><br> in the assembled string. Maybe a future
+		  // enhancement could clean out those empty pairs at
+		  // some point in the function.
+
+		  if ((numNodesProcessed > 1) && (nodeName === "P")) {
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+		  }
           break;  // break (not continue) so that child nodes are processed.
 
         case goog.dom.TagName.BR:

--- a/closure/goog/ui/datepicker.js
+++ b/closure/goog/ui/datepicker.js
@@ -201,9 +201,18 @@ goog.ui.DatePicker.prototype.showOtherMonths_ = true;
  * @type {goog.date.DateRange}
  * @private
  */
-goog.ui.DatePicker.prototype.userSelectableDateRange_ =
-    goog.date.DateRange.allTime();
 
+// This changes the called DateRange function call from
+// allTime() to thisMonth(this.date_) so that
+// the user can only click a day inside the displayed
+// month, not days "visible" outside that month. See
+//
+//   https://github.com/google/closure-library/issues/415
+//
+// for more information.
+
+goog.ui.DatePicker.prototype.userSelectableDateRange_ =
+    goog.date.DateRange.thisMonth(this.date_);
 
 /**
  * Flag indicating if extra week(s) always should be added at the end. If not


### PR DESCRIPTION
This PR fixes issue #415: goog.ui.DatePicker allows selection of dates in other months when ShowOtherMonths is false.