### PR TITLE
This PR fixes a bug that will "arbitrarily" delete text in the Google Editor. This usually happens when the user first starts using a fresh Google Editor.

### DIFF
--- a/closure/goog/demos/editor/editor.html
+++ b/closure/goog/demos/editor/editor.html
@@ -77,7 +77,28 @@ hooked up to a toolbar.</p>
 
   <script>
   function updateFieldContents() {
-    goog.dom.getElement('fieldContents').value = myField.getCleanContents();
+
+  // This function must call myField.getCleanContents() because
+  // getCleanContents() itself directly and indirectly calls
+  // other functions the editor needs. For whatever reason, the
+  // editor loads with
+  //
+  //	USING_LOREM 
+  //
+  // from
+  //
+  //	editor\command.js
+  //
+  // already set and this would overwrite the value in the lower
+  // 'fieldContents' textarea.
+
+    var getCleanContentsRetVal = myField.getCleanContents();
+
+  // This block changes the original unrestricted call to getCleanContents().
+
+	if (getCleanContentsRetVal !== goog.string.Unicode.NBSP){
+	  goog.dom.getElement('fieldContents').value = getCleanContentsRetVal;
+	}
   }
 
   // Create an editable field.
@@ -133,7 +154,11 @@ hooked up to a toolbar.</p>
       updateFieldContents);
 
   myField.makeEditable();
-  updateFieldContents();
+
+  // Remove call to updateFieldContents() here because this function
+  // places an &nbsp in 'fieldContents' - the lower textarea in the
+  // editor.
+
   </script>
 </body>
 </html>

--- a/closure/goog/editor/field.js
+++ b/closure/goog/editor/field.js
@@ -1907,7 +1907,14 @@ goog.editor.Field.prototype.dispatchBeforeFocus_ = function() {
     return;
   }
 
-  this.execCommand(goog.editor.Command.CLEAR_LOREM, true);
+  // Add a new parameter to this function that will control
+  // the call to function setHTML() in clearLorem_ . This
+  // approach will not break other calls to clearLorem_
+  // because Javascript will simply assign the value "undefined"
+  // to the parameter if similar calls to CLEAR_LOREM have only
+  // two parameters.
+  
+  this.execCommand(goog.editor.Command.CLEAR_LOREM, true, false);
   this.dispatchEvent(goog.editor.Field.EventType.BEFOREFOCUS);
 };
 

--- a/closure/goog/editor/plugins/loremipsum.js
+++ b/closure/goog/editor/plugins/loremipsum.js
@@ -89,11 +89,16 @@ goog.editor.plugins.LoremIpsum.prototype.queryCommandValue = function(command) {
  * @param {*=} opt_placeCursor Whether to place the cursor in the field
  *     after clearing lorem. Should be a boolean.
  * @override
+ *
+ * Added a new parameter to clearLorem_ - opt_SetHTML.
+ * This controls the call to the javascript function
+ * setHTML; this function clears out the text in the
+ * 'editMe' textarea.
  */
 goog.editor.plugins.LoremIpsum.prototype.execCommand = function(command,
-    opt_placeCursor) {
+    opt_placeCursor, opt_SetHTML) {
   if (command == goog.editor.Command.CLEAR_LOREM) {
-    this.clearLorem_(!!opt_placeCursor);
+    this.clearLorem_(!!opt_placeCursor, opt_SetHTML);
   } else if (command == goog.editor.Command.UPDATE_LOREM) {
     this.updateLorem_();
   }
@@ -147,7 +152,10 @@ goog.editor.plugins.LoremIpsum.prototype.updateLorem_ = function() {
 
 
 /**
- * Clear an EditableField's lorem ipsum and put in initial text if needed.
+ * The goog.editor utility has a bug that deletes text in the 'editMe' textarea
+ * when the user first clicks inside it. This is part of the repair. Add a new
+ * parameter "opt_SetHTML" to control the call to setHtml - the function that
+ * clears the HTML in 'editMe'.
  *
  * If using click-to-edit mode (where Trogedit manages whether the field
  * is editable), this works for both editable and uneditable fields.
@@ -158,7 +166,7 @@ goog.editor.plugins.LoremIpsum.prototype.updateLorem_ = function() {
  * @private
  */
 goog.editor.plugins.LoremIpsum.prototype.clearLorem_ = function(
-    opt_placeCursor) {
+    opt_placeCursor, opt_SetHTML) {
   // Don't mess with lorem state when a dialog is open as that screws
   // with the dialog's ability to properly restore the selection
   // on dialog close (since the DOM nodes would get clobbered)
@@ -174,7 +182,16 @@ goog.editor.plugins.LoremIpsum.prototype.clearLorem_ = function(
     goog.asserts.assert(field);
     this.usingLorem_ = false;
     field.style.fontStyle = this.oldFontStyle_;
-    fieldObj.setHtml(true, null, true);
+
+	// Existing code might call clearLorem_ with only one
+	// parameter and in those situations, opt_SetHTML is
+	// undefined. Therefore, to preserve existing behavior,
+	// call setHTML if the opt_SetHTML parameter is undefined
+	// or as a specific true value.
+
+	if ((opt_SetHTML == true) || (opt_SetHTML == undefined)) {
+		fieldObj.setHtml(true, null, true);
+	}
 
     // TODO(nicksantos): I'm pretty sure that this is a hack, but talk to
     // Julie about why this is necessary and what to do with it. Really,

--- a/closure/goog/editor/plugins/removeformatting.js
+++ b/closure/goog/editor/plugins/removeformatting.js
@@ -651,8 +651,21 @@ goog.editor.plugins.RemoveFormatting.prototype.removeFormattingWorker_ =
           continue;
 
         case goog.dom.TagName.P:
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+
+		  // Make sure the "P" paragraph tag is not the first
+		  // node processed. This prevents an "extra" blank
+		  // line at the top of selected text that starts with
+		  // a paragraph tag. The "Set Field Contents" onclick
+		  // will rebalance all unmatched <p> and/or </p> tags,
+		  // but note that all empty <p></p> pairs will become
+		  // <br><br> in the assembled string. Maybe a future
+		  // enhancement could clean out those empty pairs at
+		  // some point in the function.
+
+		  if ((numNodesProcessed > 1) && (nodeName === "P")) {
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+		  }
           break;  // break (not continue) so that child nodes are processed.
 
         case goog.dom.TagName.BR:


### PR DESCRIPTION
This PR fixes a bug that will "arbitrarily" delete text in the Google Editor. This usually happens when the user first starts using a fresh Google Editor.

"Soon" after the Google Editor

http://www.closurecheatsheet.com/demos/demos/editor/editor.html

first opens, it can sometimes delete text in either of the textareas if the user clicks in either of those textareas. This bug will disappear after "a little bit" of Google Editor use; this PR is a permanent fix.