### PR TITLE
Fix the IE10+ SCRIPT65535 error in goog.events.FileDropHandler

### DIFF
--- a/closure/goog/events/filedrophandler.js
+++ b/closure/goog/events/filedrophandler.js
@@ -196,7 +196,10 @@ goog.events.FileDropHandler.prototype.onElemDragOver_ = function(e) {
     e.stopPropagation();
     // Allow the drop on the drop zone.
     var dt = e.getBrowserEvent().dataTransfer;
-    dt.effectAllowed = 'all';
+    // Temporarily solution to prevent IE10+ SCRIPT65535 error, see more at https://github.com/google/closure-library/issues/485
+    try {
+        dt.effectAllowed = 'all';
+    } catch (e) {}
     dt.dropEffect = 'copy';
   }
 };

--- a/closure/goog/events/filedrophandler.js
+++ b/closure/goog/events/filedrophandler.js
@@ -196,7 +196,10 @@ goog.events.FileDropHandler.prototype.onElemDragOver_ = function(e) {
     e.stopPropagation();
     // Allow the drop on the drop zone.
     var dt = e.getBrowserEvent().dataTransfer;
-    // Temporarily solution to prevent IE10+ SCRIPT65535 error, see more at https://github.com/google/closure-library/issues/485
+
+    // IE bug #811625 (https://goo.gl/UWuxX0) will throw error SCRIPT65535
+    // when attemp to set property effectAllowed on IE10+.
+    // See more: https://github.com/google/closure-library/issues/485
     try {
       dt.effectAllowed = 'all';
     } catch (e) {}

--- a/closure/goog/events/filedrophandler.js
+++ b/closure/goog/events/filedrophandler.js
@@ -198,7 +198,7 @@ goog.events.FileDropHandler.prototype.onElemDragOver_ = function(e) {
     var dt = e.getBrowserEvent().dataTransfer;
     // Temporarily solution to prevent IE10+ SCRIPT65535 error, see more at https://github.com/google/closure-library/issues/485
     try {
-        dt.effectAllowed = 'all';
+      dt.effectAllowed = 'all';
     } catch (e) {}
     dt.dropEffect = 'copy';
   }

--- a/closure/goog/events/filedrophandler_test.js
+++ b/closure/goog/events/filedrophandler_test.js
@@ -250,15 +250,16 @@ function testPreventDropOutside() {
 }
 
 function testEffectAllowedExceptionIsCaught() {
-  // See more at https://github.com/google/closure-library/issues/485
-  // or https://connect.microsoft.com/IE/feedback/details/811625/cant-get-datatransfer-effectallowed-set-in-another-window-raises-a-script65535-error
   var preventDefault = false;
   var expectedfiles = [{ fileName: 'file1.jpg' }];
   var dt = { types: ['Files'], files: expectedfiles };
-  // we construct a mock DataTransfer object and define a setter will throw SCRIPT65535 when attempt to set effectAllowed to simulate the IEBug #811625
+
+  // We construct a mock DataTransfer object that define a setter will throw SCRIPT65535
+  // when attempt to set property effectAllowed to simulate IE Bug #811625.
+  // See more: https://github.com/google/closure-library/issues/485
   Object.defineProperty(dt, 'effectAllowed', {
     set: function(v) {
-      throw new Error("SCRIPT65535: see more at https://connect.microsoft.com/IE/feedback/details/811625/cant-get-datatransfer-effectallowed-set-in-another-window-raises-a-script65535-error")
+      throw new Error("SCRIPT65535");
     }
   });
 

--- a/closure/goog/events/filedrophandler_test.js
+++ b/closure/goog/events/filedrophandler_test.js
@@ -249,16 +249,18 @@ function testPreventDropOutside() {
   assertEquals('none', dt.dropEffect);
 }
 
-function testIEBugNo811625() {
+function testEffectAllowedExceptionIsCaught() {
   // See more at https://github.com/google/closure-library/issues/485
   // or https://connect.microsoft.com/IE/feedback/details/811625/cant-get-datatransfer-effectallowed-set-in-another-window-raises-a-script65535-error
   var preventDefault = false;
   var expectedfiles = [{ fileName: 'file1.jpg' }];
   var dt = { types: ['Files'], files: expectedfiles };
   // we construct a mock DataTransfer object and define a setter will throw SCRIPT65535 when attempt to set effectAllowed to simulate the IEBug #811625
-  dt.__defineSetter__('effectAllowed', function(v){
-    throw new Error("SCRIPT65535: see more at https://connect.microsoft.com/IE/feedback/details/811625/cant-get-datatransfer-effectallowed-set-in-another-window-raises-a-script65535-error")
-  })
+  Object.defineProperty(dt, 'effectAllowed', {
+    set: function(v) {
+      throw new Error("SCRIPT65535: see more at https://connect.microsoft.com/IE/feedback/details/811625/cant-get-datatransfer-effectallowed-set-in-another-window-raises-a-script65535-error")
+    }
+  });
 
   // Assert that default actions are prevented on dragenter.
   textarea.dispatchEvent(new goog.events.BrowserEvent({
@@ -276,21 +278,4 @@ function testIEBugNo811625() {
     dataTransfer: dt
   }));
   assertTrue(preventDefault);
-  preventDefault = false;
-  // Assert that the drop effect is set to 'copy'.
-  assertEquals('copy', dt.dropEffect);
-
-  // Assert that default actions are prevented on drop.
-  textarea.dispatchEvent(new goog.events.BrowserEvent({
-    preventDefault: function() { preventDefault = true; },
-    type: goog.events.EventType.DROP,
-    dataTransfer: dt
-  }));
-  assertTrue(preventDefault);
-
-  // Assert that DROP has been fired.
-  assertTrue(dnd);
-  assertEquals(1, files.length);
-  assertEquals(expectedfiles[0].fileName, files[0].fileName);
 }
-


### PR DESCRIPTION
See more at https://github.com/google/closure-library/issues/485