### PR TITLE
Fix tabs in keyhandler.html and roll back changes in removeformatting.js .

### DIFF
--- a/closure/goog/date/date.js
+++ b/closure/goog/date/date.js
@@ -243,7 +243,24 @@ goog.date.getWeekNumber = function(year, month, date, opt_weekDay,
   var d = new Date(year, month, date);
 
   // Default to Thursday for cut off as per ISO 8601.
-  var cutoff = opt_weekDay || goog.date.weekDay.THU;
+  
+  var cutoff;
+
+  // @param opt_weekDay might have an intended 0 value, but
+  // if it does, the original cutoff calculation will set a
+  // value of goog.date.weekDay.THU, which is 4. This block
+  // accounts for this case, and it won't break any earlier
+  // workarounds. Test for opt_weekDay === 'undefined' because
+  // an existing production call to this function might have
+  // an undefined value for this parameter.
+  
+  if (typeof opt_weekDay === 'undefined'){
+	cutoff = goog.date.weekDay.THU;
+  } else if (opt_weekDay === 7) {
+	cutoff = 0;
+  } else {
+	cutoff = opt_weekDay;
+  }
 
   // Default to Monday for first day of the week as per ISO 8601.
   var firstday = opt_firstDayOfWeek || goog.date.weekDay.MON;
@@ -477,7 +494,6 @@ goog.date.setIso8601TimeOnly_ = function(d, formatted) {
  * @param {number=} opt_minutes Minutes.
  * @param {number=} opt_seconds Seconds.
  * @constructor
- * @struct
  * @final
  */
 goog.date.Interval = function(opt_years, opt_months, opt_days, opt_hours,
@@ -749,7 +765,6 @@ goog.date.Interval.prototype.add = function(interval) {
  * @param {number=} opt_month Month, 0 = Jan, 11 = Dec.
  * @param {number=} opt_date Date of month, 1 - 31.
  * @constructor
- * @struct
  * @see goog.date.DateTime
  */
 goog.date.Date = function(opt_year, opt_month, opt_date) {
@@ -870,18 +885,18 @@ goog.date.Date.prototype.getTime = function() {
 
 
 /**
- * @return {number} The day of week, US style. 0 = Sun, 6 = Sat.
+ * @return {goog.date.weekDay} The day of week, US style. 0 = Sun, 6 = Sat.
  */
 goog.date.Date.prototype.getDay = function() {
-  return this.date.getDay();
+  return /** @type {goog.date.weekDay} */ (this.date.getDay());
 };
 
 
 /**
- * @return {goog.date.weekDay} The day of week, ISO style. 0 = Mon, 6 = Sun.
+ * @return {number} The day of week, ISO style. 0 = Mon, 6 = Sun.
  */
 goog.date.Date.prototype.getIsoWeekday = function() {
-  return /** @type {goog.date.weekDay} */ ((this.getDay() + 6) % 7);
+  return (this.getDay() + 6) % 7;
 };
 
 
@@ -919,11 +934,11 @@ goog.date.Date.prototype.getUTCDate = function() {
 
 
 /**
- * @return {number} The day of week according to universal time, US style.
- *     0 = Sun, 1 = Mon, 6 = Sat.
+ * @return {goog.date.weekDay} The day of week according to universal time,
+ *     US style. 0 = Sun, 1 = Mon, 6 = Sat.
  */
 goog.date.Date.prototype.getUTCDay = function() {
-  return this.date.getDay();
+  return /** @type {goog.date.weekDay} */ (this.date.getDay());
 };
 
 
@@ -944,11 +959,11 @@ goog.date.Date.prototype.getUTCMinutes = function() {
 
 
 /**
- * @return {goog.date.weekDay} The day of week according to universal time, ISO
- *     style. 0 = Mon, 6 = Sun.
+ * @return {number} The day of week according to universal time, ISO style.
+ *     0 = Mon, 6 = Sun.
  */
 goog.date.Date.prototype.getUTCIsoWeekday = function() {
-  return /** @type {goog.date.weekDay} */ ((this.date.getUTCDay() + 6) % 7);
+  return (this.date.getUTCDay() + 6) % 7;
 };
 
 
@@ -1330,7 +1345,6 @@ goog.date.Date.compare = function(date1, date2) {
  * @param {number=} opt_seconds Seconds, 0 - 61.
  * @param {number=} opt_milliseconds Milliseconds, 0 - 999.
  * @constructor
- * @struct
  * @extends {goog.date.Date}
  */
 goog.date.DateTime = function(opt_year, opt_month, opt_date, opt_hours,

--- a/closure/goog/demos/editor/editor.html
+++ b/closure/goog/demos/editor/editor.html
@@ -1,7 +1,6 @@
 <html>
 <!--
 Copyright 2009 The Closure Library Authors. All Rights Reserved.
-
 Use of this source code is governed by the Apache License, Version 2.0.
 See the COPYING file for details.
 -->
@@ -77,12 +76,31 @@ hooked up to a toolbar.</p>
 
   <script>
   function updateFieldContents() {
-    goog.dom.getElement('fieldContents').value = myField.getCleanContents();
-  }
 
+  // This function must call myField.getCleanContents() because
+  // getCleanContents() itself directly and indirectly calls
+  // other functions the editor needs. For whatever reason, the
+  // editor loads with
+  //
+  //	USING_LOREM 
+  //
+  // from
+  //
+  //	editor\command.js
+  //
+  // already set and this would overwrite the value in the lower
+  // 'fieldContents' textarea.
+
+    var getCleanContentsRetVal = myField.getCleanContents();
+
+  // This block changes the original unrestricted call to getCleanContents().
+
+	if (getCleanContentsRetVal !== goog.string.Unicode.NBSP){
+	  goog.dom.getElement('fieldContents').value = getCleanContentsRetVal;
+	}
+  }
   // Create an editable field.
   var myField = new goog.editor.Field('editMe');
-
   // Create and register all of the editing plugins you want to use.
   myField.registerPlugin(new goog.editor.plugins.BasicTextFormatter());
   myField.registerPlugin(new goog.editor.plugins.RemoveFormatting());
@@ -96,7 +114,6 @@ hooked up to a toolbar.</p>
   myField.registerPlugin(
       new goog.editor.plugins.LinkDialogPlugin());
   myField.registerPlugin(new goog.editor.plugins.LinkBubble());
-
   // Specify the buttons to add to the toolbar, using built in default buttons.
   var buttons = [
     goog.editor.Command.BOLD,
@@ -123,17 +140,19 @@ hooked up to a toolbar.</p>
   ];
   var myToolbar = goog.ui.editor.DefaultToolbar.makeToolbar(buttons,
       goog.dom.getElement('toolbar'));
-
   // Hook the toolbar into the field.
   var myToolbarController =
       new goog.ui.editor.ToolbarController(myField, myToolbar);
-
   // Watch for field changes, to display below.
+
   goog.events.listen(myField, goog.editor.Field.EventType.DELAYEDCHANGE,
       updateFieldContents);
-
   myField.makeEditable();
-  updateFieldContents();
+
+  // Remove call to updateFieldContents() here because this function
+  // places an &nbsp in 'fieldContents' - the lower textarea in the
+  // editor.
+
   </script>
 </body>
 </html>

--- a/closure/goog/demos/keyhandler.html
+++ b/closure/goog/demos/keyhandler.html
@@ -98,6 +98,20 @@ function numberInputKeyHandler(e) {
   }
 
   switch (e.keyCode) {
+
+  // Add the keycodes for the number-pad keys
+
+    case goog.events.KeyCodes.NUM_ZERO:
+    case goog.events.KeyCodes.NUM_ONE:
+    case goog.events.KeyCodes.NUM_TWO:
+    case goog.events.KeyCodes.NUM_THREE:
+    case goog.events.KeyCodes.NUM_FOUR:
+    case goog.events.KeyCodes.NUM_FIVE:
+    case goog.events.KeyCodes.NUM_SIX:
+    case goog.events.KeyCodes.NUM_SEVEN:
+    case goog.events.KeyCodes.NUM_EIGHT:
+    case goog.events.KeyCodes.NUM_NINE:
+
     // Allow these
     case goog.events.KeyCodes.DELETE:
     case goog.events.KeyCodes.BACKSPACE:

--- a/closure/goog/editor/plugins/removeformatting.js
+++ b/closure/goog/editor/plugins/removeformatting.js
@@ -651,8 +651,21 @@ goog.editor.plugins.RemoveFormatting.prototype.removeFormattingWorker_ =
           continue;
 
         case goog.dom.TagName.P:
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
-          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+
+		  // Make sure the "P" paragraph tag is not the first
+		  // node processed. This prevents an "extra" blank
+		  // line at the top of selected text that starts with
+		  // a paragraph tag. The "Set Field Contents" onclick
+		  // will rebalance all unmatched <p> and/or </p> tags,
+		  // but note that all empty <p></p> pairs will become
+		  // <br><br> in the assembled string. Maybe a future
+		  // enhancement could clean out those empty pairs at
+		  // some point in the function.
+
+		  if ((numNodesProcessed > 1) && (nodeName === "P")) {
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+		  }
           break;  // break (not continue) so that child nodes are processed.
 
         case goog.dom.TagName.BR:

--- a/closure/goog/editor/plugins/removeformatting.js
+++ b/closure/goog/editor/plugins/removeformatting.js
@@ -651,21 +651,8 @@ goog.editor.plugins.RemoveFormatting.prototype.removeFormattingWorker_ =
           continue;
 
         case goog.dom.TagName.P:
-
-		  // Make sure the "P" paragraph tag is not the first
-		  // node processed. This prevents an "extra" blank
-		  // line at the top of selected text that starts with
-		  // a paragraph tag. The "Set Field Contents" onclick
-		  // will rebalance all unmatched <p> and/or </p> tags,
-		  // but note that all empty <p></p> pairs will become
-		  // <br><br> in the assembled string. Maybe a future
-		  // enhancement could clean out those empty pairs at
-		  // some point in the function.
-
-		  if ((numNodesProcessed > 1) && (nodeName === "P")) {
-            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
-            goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
-		  }
+          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
+          goog.editor.plugins.RemoveFormatting.appendNewline_(sb);
           break;  // break (not continue) so that child nodes are processed.
 
         case goog.dom.TagName.BR:

--- a/closure/goog/ui/datepicker.js
+++ b/closure/goog/ui/datepicker.js
@@ -201,9 +201,18 @@ goog.ui.DatePicker.prototype.showOtherMonths_ = true;
  * @type {goog.date.DateRange}
  * @private
  */
-goog.ui.DatePicker.prototype.userSelectableDateRange_ =
-    goog.date.DateRange.allTime();
 
+// This changes the called DateRange function call from
+// allTime() to thisMonth(this.date_) so that
+// the user can only click a day inside the displayed
+// month, not days "visible" outside that month. See
+//
+//   https://github.com/google/closure-library/issues/415
+//
+// for more information.
+
+goog.ui.DatePicker.prototype.userSelectableDateRange_ =
+    goog.date.DateRange.thisMonth(this.date_);
 
 /**
  * Flag indicating if extra week(s) always should be added at the end. If not


### PR DESCRIPTION
This pull request removed tabs from keyhandler.html and rolled back the changes in removeformatting.js not needed for issue <a href="https://github.com/google/closure-library/issues/267">#267</a>.