### PR TITLE
Use a smaller digit batch size when encoding in base 36

### DIFF
--- a/closure/goog/math/integer.js
+++ b/closure/goog/math/integer.js
@@ -261,7 +261,10 @@ goog.math.Integer.prototype.toString = function(opt_radix) {
   var result = '';
   while (true) {
     var remDiv = rem.divide(radixToPower);
-    var intval = rem.subtract(remDiv.multiply(radixToPower)).toInt();
+    // The right shifting fixes negative values in the case when
+    // intval >= 2^31; for more details see
+    // https://github.com/google/closure-library/pull/498
+    var intval = rem.subtract(remDiv.multiply(radixToPower)).toInt() >>> 0;
     var digits = intval.toString(radix);
 
     rem = remDiv;

--- a/closure/goog/math/integer_test.js
+++ b/closure/goog/math/integer_test.js
@@ -1691,3 +1691,10 @@ function testBigShift() {
   assertEquals('-591981510028266767381876356163880091648',
                a.negate().shiftLeft(97).toString());
 }
+
+// Regression test for
+// https://github.com/google/closure-library/pull/498
+function testBase36ToString() {
+  assertEquals('zzzzzz',
+               goog.math.Integer.fromString('zzzzzz', 36).toString(36));
+}

--- a/closure/goog/math/long.js
+++ b/closure/goog/math/long.js
@@ -380,7 +380,10 @@ goog.math.Long.prototype.toString = function(opt_radix) {
   var result = '';
   while (true) {
     var remDiv = rem.div(radixToPower);
-    var intval = rem.subtract(remDiv.multiply(radixToPower)).toInt();
+    // The right shifting fixes negative values in the case when
+    // intval >= 2^31; for more details see
+    // https://github.com/google/closure-library/pull/498
+    var intval = rem.subtract(remDiv.multiply(radixToPower)).toInt() >>> 0;
     var digits = intval.toString(radix);
 
     rem = remDiv;

--- a/closure/goog/math/long_test.js
+++ b/closure/goog/math/long_test.js
@@ -1569,3 +1569,9 @@ function createTestToFromString(i) {
 for (var i = 0; i < TEST_BITS.length; i += 2) {
   goog.global['testToFromString' + i] = createTestToFromString(i);
 }
+
+// Regression test for
+// https://github.com/google/closure-library/pull/498
+function testBase36ToString() {
+  assertEquals('zzzzzz', goog.math.Long.fromString('zzzzzz', 36).toString(36));
+}


### PR DESCRIPTION
There was a bug in the Integer#toString function for base 36, due to the
way it computes six digits at a time, and the fact that 36^6 > 2^31.
Since 35^6 < 2^31 this is only a problem for base 36, and can be fixed
by checking the radix and switching to five digits if it happens to be
36.