### PR TITLE
Wrong catch property name

### DIFF
--- a/closure/goog/events/filedrophandler.js
+++ b/closure/goog/events/filedrophandler.js
@@ -202,7 +202,7 @@ goog.events.FileDropHandler.prototype.onElemDragOver_ = function(e) {
     // See more: https://github.com/google/closure-library/issues/485.
     try {
       dt.effectAllowed = 'all';
-    } catch (e) {
+    } catch (err) {
     }
     dt.dropEffect = 'copy';
   }


### PR DESCRIPTION
Compiler output:
```
>> /var/folders/pl/w4db0j4d5gq8zk1lt6tgr34c0000gn/T/1438592089178.1658/bower_components/closure-library/closure/goog/events/filedrophandler.js:205: WARNING - Redeclared variable: e
>>     } catch (e) {
>>              ^
>> 
>> 0 error(s), 1 warning(s), 94.3% typed
```