### PR TITLE
Add warning_level VERBOSE to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
   - cd ../closure-library
 
 script:
-  - java -jar ../closure-compiler/build/compiler.jar -O ADVANCED --js='**.js' --js='!**_test.js' --js='!**_perf.js' --js_output_file=$(mktemp)
+  - java -jar ../closure-compiler/build/compiler.jar -O ADVANCED --warning_level VERBOSE --js='**.js' --js='!**_test.js' --js='!**_perf.js' --js='!**tester.js' --js='!**promise/testsuiteadapter.js' --js='!**osapi/osapi.js' --js='!**svgpan/svgpan.js' --jscomp_off=deprecated   --js_output_file=$(mktemp)


### PR DESCRIPTION
Make the compilation test stricter by setting --warning_level VERBOSE to make the task compile clean, I've disabled the deprecation warnings and removed a couple files that depend on non-standard externs:
  promise/testsuiteadapter.js
  osapi/osapi.js
  svgpan/svgpan.js
and excluded "*tester.js" (unit test support files that conflict with each other).