### PR TITLE
Added missing drag event to goog.fx.AbstractDragDrop.

### DIFF
--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -588,7 +588,7 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
       event.clientY,
       x,
       y
-  ));
+      ));
 
   // Check if we're still inside the bounds of the active target, if not fire
   // a dragout event and proceed to find a new target.

--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -575,10 +575,23 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
   var x = position.x;
   var y = position.y;
 
-  // Check if we're still inside the bounds of the active target, if not fire
-  // a dragout event and proceed to find a new target.
   var activeTarget = this.activeTarget_;
 
+  // Dispatch a drag event
+  this.dispatchEvent(new goog.fx.DragDropEvent(
+    goog.fx.AbstractDragDrop.EventType.DRAG,
+    this, this.dragItem_,
+    activeTarget ? activeTarget.target_ : undefined,
+    activeTarget ? activeTarget.item_ : undefined,
+    activeTarget ? activeTarget.element_ : undefined,
+    event.clientX,
+    event.clientY,
+    x,
+    y
+  ));
+
+  // Check if we're still inside the bounds of the active target, if not fire
+  // a dragout event and proceed to find a new target.
   var subtarget;
   if (activeTarget) {
     // If a subtargeting function is enabled get the current subtarget

--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -579,15 +579,15 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
 
   // Dispatch a drag event
   this.dispatchEvent(new goog.fx.DragDropEvent(
-    goog.fx.AbstractDragDrop.EventType.DRAG,
-    this, this.dragItem_,
-    activeTarget ? activeTarget.target_ : undefined,
-    activeTarget ? activeTarget.item_ : undefined,
-    activeTarget ? activeTarget.element_ : undefined,
-    event.clientX,
-    event.clientY,
-    x,
-    y
+      goog.fx.AbstractDragDrop.EventType.DRAG,
+      this, this.dragItem_,
+      activeTarget ? activeTarget.target_ : undefined,
+      activeTarget ? activeTarget.item_ : undefined,
+      activeTarget ? activeTarget.element_ : undefined,
+      event.clientX,
+      event.clientY,
+      x,
+      y
   ));
 
   // Check if we're still inside the bounds of the active target, if not fire

--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -577,18 +577,12 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
 
   var activeTarget = this.activeTarget_;
 
-  // Dispatch a drag event
   this.dispatchEvent(new goog.fx.DragDropEvent(
-      goog.fx.AbstractDragDrop.EventType.DRAG,
-      this, this.dragItem_,
+      goog.fx.AbstractDragDrop.EventType.DRAG, this, this.dragItem_,
       activeTarget ? activeTarget.target_ : undefined,
       activeTarget ? activeTarget.item_ : undefined,
       activeTarget ? activeTarget.element_ : undefined,
-      event.clientX,
-      event.clientY,
-      x,
-      y
-      ));
+      event.clientX, event.clientY, x, y));
 
   // Check if we're still inside the bounds of the active target, if not fire
   // a dragout event and proceed to find a new target.


### PR DESCRIPTION
Until now the drag event was only fired just before the drop event — not continuously while dragging.
Now it dispatches a drag event for every drag event it receives from goog.fx.Dragger, making the event dispatching behavior of the two classes identical.