### PR TITLE
Fixed IE Edge bug in goog.fx.Dragger

### DIFF
--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -588,7 +588,7 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
       event.clientY,
       x,
       y
-  ));
+      ));
 
   // Check if we're still inside the bounds of the active target, if not fire
   // a dragout event and proceed to find a new target.

--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -575,10 +575,23 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
   var x = position.x;
   var y = position.y;
 
-  // Check if we're still inside the bounds of the active target, if not fire
-  // a dragout event and proceed to find a new target.
   var activeTarget = this.activeTarget_;
 
+  // Dispatch a drag event
+  this.dispatchEvent(new goog.fx.DragDropEvent(
+    goog.fx.AbstractDragDrop.EventType.DRAG,
+    this, this.dragItem_,
+    activeTarget ? activeTarget.target_ : undefined,
+    activeTarget ? activeTarget.item_ : undefined,
+    activeTarget ? activeTarget.element_ : undefined,
+    event.clientX,
+    event.clientY,
+    x,
+    y
+  ));
+
+  // Check if we're still inside the bounds of the active target, if not fire
+  // a dragout event and proceed to find a new target.
   var subtarget;
   if (activeTarget) {
     // If a subtargeting function is enabled get the current subtarget

--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -579,15 +579,15 @@ goog.fx.AbstractDragDrop.prototype.moveDrag_ = function(event) {
 
   // Dispatch a drag event
   this.dispatchEvent(new goog.fx.DragDropEvent(
-    goog.fx.AbstractDragDrop.EventType.DRAG,
-    this, this.dragItem_,
-    activeTarget ? activeTarget.target_ : undefined,
-    activeTarget ? activeTarget.item_ : undefined,
-    activeTarget ? activeTarget.element_ : undefined,
-    event.clientX,
-    event.clientY,
-    x,
-    y
+      goog.fx.AbstractDragDrop.EventType.DRAG,
+      this, this.dragItem_,
+      activeTarget ? activeTarget.target_ : undefined,
+      activeTarget ? activeTarget.item_ : undefined,
+      activeTarget ? activeTarget.element_ : undefined,
+      event.clientX,
+      event.clientY,
+      x,
+      y
   ));
 
   // Check if we're still inside the bounds of the active target, if not fire

--- a/closure/goog/fx/dragger.js
+++ b/closure/goog/fx/dragger.js
@@ -212,11 +212,7 @@ goog.tagUnsealableClass(goog.fx.Dragger);
  * @type {boolean}
  * @private
  */
-goog.fx.Dragger.HAS_SET_CAPTURE_ =
-    // IE and Gecko after 1.9.3 has setCapture
-    // WebKit does not yet: https://bugs.webkit.org/show_bug.cgi?id=27330
-    goog.userAgent.IE ||
-    goog.userAgent.GECKO && goog.userAgent.isVersionOrHigher('1.9.3');
+goog.fx.Dragger.HAS_SET_CAPTURE_ = goog.isDef(goog.global.document.documentElement.setCapture);
 
 
 /**


### PR DESCRIPTION
Changed the check for support for setCapture() in goog.fx.Dragger from user agent sniffing to feature detection to make it work in IE Edge, which doesn't support setCapture.