### PR TITLE
Update local currency symbol for DKK

### DIFF
--- a/closure/goog/i18n/currency.js
+++ b/closure/goog/i18n/currency.js
@@ -284,7 +284,7 @@ goog.i18n.currency.CurrencyInfo = {
   'COP': [0, '$', 'COL$'],
   'CRC': [0, '\u20a1', 'CR\u20a1'],
   'CZK': [50, 'K\u010d', 'K\u010d'],
-  'DKK': [18, 'kr', 'kr'],
+  'DKK': [50, 'kr.', 'kr.'],
   'DOP': [2, '$', 'RD$'],
   'EGP': [2, '£', 'LE'],
   'ETB': [2, 'Birr', 'Birr'],

--- a/closure/goog/i18n/currencycodemap.js
+++ b/closure/goog/i18n/currencycodemap.js
@@ -50,7 +50,7 @@ goog.i18n.currencyCodeMap = {
   'CRC': '\u20a1',
   'CUP': '$',
   'CZK': 'K\u010d',
-  'DKK': 'kr',
+  'DKK': 'kr.',
   'DOP': '$',
   'EGP': '\u00a3',
   'EUR': '\u20ac',


### PR DESCRIPTION
The local currency symbol for DKK should be changed from ``kr`` to ``kr.`` (note the trailing period).

``kr.`` has always been the official Danish abbreviation, but the ``kr``variant has also existed in glibc until recently (perhaps this how it made its way into Closure initially):
https://sourceware.org/bugzilla/show_bug.cgi?id=17692
