### PR TITLE
Enriched the drag end event in goog.fx.AbstractDragDrop 

### DIFF
--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -518,7 +518,9 @@ goog.fx.AbstractDragDrop.prototype.endDrag = function(event) {
 
   var dragEndEvent = new goog.fx.DragDropEvent(
       goog.fx.AbstractDragDrop.EventType.DRAGEND, this, this.dragItem_,
-      activeTarget.target_, activeTarget.item_, activeTarget.element_);
+      activeTarget ? activeTarget.target_ : undefined,
+      activeTarget ? activeTarget.item_ : undefined,
+      activeTarget ? activeTarget.element_ : undefined);
   this.dispatchEvent(dragEndEvent);
 
   goog.events.unlisten(this.dragger_, goog.fx.Dragger.EventType.DRAG,

--- a/closure/goog/fx/abstractdragdrop.js
+++ b/closure/goog/fx/abstractdragdrop.js
@@ -517,7 +517,8 @@ goog.fx.AbstractDragDrop.prototype.endDrag = function(event) {
   }
 
   var dragEndEvent = new goog.fx.DragDropEvent(
-      goog.fx.AbstractDragDrop.EventType.DRAGEND, this, this.dragItem_);
+      goog.fx.AbstractDragDrop.EventType.DRAGEND, this, this.dragItem_,
+      activeTarget.target_, activeTarget.item_, activeTarget.element_);
   this.dispatchEvent(dragEndEvent);
 
   goog.events.unlisten(this.dragger_, goog.fx.Dragger.EventType.DRAG,

--- a/closure/goog/fx/abstractdragdrop_test.js
+++ b/closure/goog/fx/abstractdragdrop_test.js
@@ -618,6 +618,55 @@ function testGetDragElementPosition() {
       'margins', pageOffset.y - 14, pos.y);
 }
 
+function testDragEndEvent() {
+  function testDragEndEventInternal(shouldContainItemData) {
+    var testGroup = new goog.fx.AbstractDragDrop();
+
+    var childEl = document.getElementById('child1');
+    var item = new goog.fx.DragDropItem(childEl);
+    item.currentDragElement_ = childEl;
+
+    testGroup.items_.push(item);
+    testGroup.recalculateDragTargets();
+
+    // Simulate starting a drag
+    var startEvent = {'clientX': 0, 'clientY': 0,
+      'type': goog.events.EventType.MOUSEMOVE, 'relatedTarget': childEl,
+      'preventDefault': function() {}};
+    testGroup.startDrag(startEvent, item);
+
+    testGroup.activeTarget_ = new goog.fx.ActiveDropTarget_(
+        new goog.math.Box(0, 0, 0, 0), testGroup, item, childEl);
+
+    goog.events.listen(testGroup, goog.fx.AbstractDragDrop.EventType.DRAGEND,
+        function(event) {
+          if (shouldContainItemData) {
+            assertEquals('The drag end event should contain a drop target',
+                testGroup, event.dropTarget);
+            assertEquals('The drag end event should contain a drop target item',
+                item, event.dropTargetItem);
+            assertEquals('The drag end event should contain a drop target element',
+                childEl, event.dropTargetElement);
+          } else {
+            assertUndefined('The drag end event shouldn\'t contain a drop target',
+                event.dropTarget);
+            assertUndefined('The drag end event shouldn\'t contain a drop target item',
+                event.dropTargetItem);
+            assertUndefined('The drag end event shouldn\'t contain a drop target element',
+                event.dropTargetElement);
+          }
+        });
+
+    testGroup.endDrag({'clientX': 0, 'clientY': 0,
+      'dragCanceled': !shouldContainItemData});
+
+    testGroup.dispose();
+    item.dispose();
+  }
+
+  testDragEndEventInternal(false);
+  testDragEndEventInternal(true);
+}
 
 // Helper function for manual debugging.
 function drawTargets(targets, multiplier) {


### PR DESCRIPTION
Enriched the drag end event in goog.fx.AbstractDragDrop with drop target data, to make it possible to distinguish between successful and unsuccessful drag ends.