### PR TITLE
Fixes #126: goog.dom.xml is broken on MSIE9+

### DIFF
--- a/closure/goog/dom/xml_test.js
+++ b/closure/goog/dom/xml_test.js
@@ -76,6 +76,13 @@ function testMaxSizeInIE() {
   }
 }
 
+function testSelectSingleNodeInIe() {                                            
+  var xml = goog.dom.xml.loadXml('<a><b><c>d</c></b></a>');                      
+  var node = xml.firstChild;                                                     
+  var bNode = goog.dom.xml.selectSingleNode(node, 'b');                          
+  assertNotNull(bNode);                                                          
+}
+
 function testSetAttributes() {
   var xmlElement = goog.dom.xml.createDocument().createElement('root');
   var domElement = document.createElement(goog.dom.TagName.DIV);


### PR DESCRIPTION
This commit fixes the issue #126: goog.dom.xml is broken on MSIE9.

It has been reported this issue also affects MSIE 10 and 11.

The issue is available here: https://github.com/google/closure-library/issues/126
Original bug report: https://code.google.com/p/closure-library/issues/detail?id=456