### PR TITLE
Changed return type of goog.object.get

### DIFF
--- a/closure/goog/object/object.js
+++ b/closure/goog/object/object.js
@@ -396,7 +396,7 @@ goog.object.add = function(obj, key, val) {
  * @param {string} key The key for which to get the value.
  * @param {R=} opt_val The value to return if no item is found for the given
  *     key (default is undefined).
- * @return {V|R|undefined} The value for the given key.
+ * @return {V|R} The value for the given key.
  * @template K,V,R
  */
 goog.object.get = function(obj, key, opt_val) {


### PR DESCRIPTION
Hey,
This is a change to something very central, so if you do not want this change I do understand. But is it not true that when the optional value is set, the return value will always be this value, and in case the default return value is not set, then template value R will be undefined as return type? So the return type will be V|undefined, when opt_val is not given as parameter?
