### PR TITLE
UTF-8 encode output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Remember The Milk Inc.
 Anish Visaria <anishvisaria98@gmail.com>
 John Huân Vũ <jvu.calpoly@gmail.com>
 Peter Lu <peterlu83+github@gmail.com>
+Filipe Catraia <filipe.catraia@deliveryhero.com>

--- a/closure/bin/build/closurebuilder.py
+++ b/closure/bin/build/closurebuilder.py
@@ -250,7 +250,7 @@ def main():
       src = js_source.GetSource()
       if js_source.is_goog_module:
         src = _WrapGoogModuleSource(src)
-      out.write(src + '\n')
+      out.write(src.encode('utf-8') + '\n')
   elif output_mode == 'compiled':
     logging.warning("""\
 Closure Compiler now natively understands and orders Closure dependencies and
@@ -276,7 +276,7 @@ https://github.com/google/closure-compiler/wiki/Manage-Closure-Dependencies
         compiler_flags=options.compiler_flags)
 
     logging.info('JavaScript compilation succeeded.')
-    out.write(compiled_source)
+    out.write(compiled_source.encode('utf-8'))
 
   else:
     logging.error('Invalid value for --output flag.')


### PR DESCRIPTION
Hey,

I use Closure for a project, and compilation breaks when using certain Unicode characters. For example:

```
UnicodeEncodeError: ascii codec can't encode character u\xd7 ...
```

UTF-8 encoding the `out.write` outputs solves this issue for us. I'm not sure how valuable it is for the Closure project, but it could get other people out of trouble :)