### PR TITLE
define goog.TESTING flag

### DIFF
--- a/closure/goog/async/run.js
+++ b/closure/goog/async/run.js
@@ -102,7 +102,8 @@ goog.async.run.workQueue_ = new goog.async.WorkQueue();
 
 if (goog.DEBUG || goog.TESTING) {
   /**
-   * Reset the work queue. Only available in TESTING mode.
+   * Reset the work queue. Only available for tests in debug mode
+   * or testing mode.
    */
   goog.async.run.resetQueue = function() {
     goog.async.run.workQueueScheduled_ = false;

--- a/closure/goog/async/run.js
+++ b/closure/goog/async/run.js
@@ -100,7 +100,7 @@ goog.async.run.workQueueScheduled_ = false;
 goog.async.run.workQueue_ = new goog.async.WorkQueue();
 
 
-if (goog.TESTING) {
+if (goog.DEBUG || goog.TESTING) {
   /**
    * Reset the work queue. Only available in TESTING mode.
    */

--- a/closure/goog/async/run.js
+++ b/closure/goog/async/run.js
@@ -100,9 +100,9 @@ goog.async.run.workQueueScheduled_ = false;
 goog.async.run.workQueue_ = new goog.async.WorkQueue();
 
 
-if (goog.DEBUG) {
+if (goog.TESTING) {
   /**
-   * Reset the work queue. Only available for tests in debug mode.
+   * Reset the work queue. Only available in TESTING mode.
    */
   goog.async.run.resetQueue = function() {
     goog.async.run.workQueueScheduled_ = false;

--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -183,6 +183,13 @@ goog.define('goog.DEBUG', true);
 
 
 /**
+ * @define {boolean} TESTING indicates that this is a non-production build
+ * for testing purposes.
+ */
+goog.define('goog.TESTING', false);
+
+
+/**
  * @define {string} LOCALE defines the locale being used for compilation. It is
  * used to select locale specific data to be compiled in js binary. BUILD rule
  * can specify this value by "--define goog.LOCALE=<locale_name>" as JSCompiler


### PR DESCRIPTION
Define goog.TESTING flag which indicates that this is a non-production
build for testing purposes. Use this flag in goog.async.run in addition to
goog.DEBUG.  This allows unit tests that use goog.testing.MockClock to
run without requiring goog.DEBUG to be on.