### PR TITLE
Ensuring MatrixConstructor works for Firefox

### DIFF
--- a/closure/goog/style/transform.js
+++ b/closure/goog/style/transform.js
@@ -167,5 +167,8 @@ goog.style.transform.matrixConstructor_ =
       if (goog.isDef(goog.global['CSSMatrix'])) {
         return goog.global['CSSMatrix'];
       }
+      if (goog.isDef(goog.global['DOMMatrix'])) {
+        return goog.global['DOMMatrix'];
+      }
       return null;
     });

--- a/closure/goog/style/transform_test.js
+++ b/closure/goog/style/transform_test.js
@@ -36,9 +36,8 @@ var element;
  * @param {number} y The vertical translation
  */
 var setAndAssertTranslation = function(x, y) {
-  if (goog.userAgent.GECKO ||
-      goog.userAgent.IE && !goog.userAgent.isDocumentModeOrHigher(10)) {
-    // Mozilla and <IE10 do not support CSSMatrix.
+  if (goog.userAgent.IE && !goog.userAgent.isDocumentModeOrHigher(10)) {
+    // <IE10 do not support CSSMatrix.
     return;
   }
   var success = goog.style.transform.setTranslation(element, x, y);
@@ -60,9 +59,8 @@ var setAndAssertTranslation = function(x, y) {
  * @param {number} z The depth scale
  */
 var setAndAssertScale = function(x, y, z) {
-  if (goog.userAgent.GECKO ||
-      goog.userAgent.IE && !goog.userAgent.isDocumentModeOrHigher(10)) {
-    // Mozilla and <IE10 do not support CSSMatrix.
+  if (goog.userAgent.IE && !goog.userAgent.isDocumentModeOrHigher(10)) {
+    // <IE10 do not support CSSMatrix.
     return;
   }
   var success = goog.style.transform.setScale(element, x, y, z);
@@ -100,7 +98,7 @@ function testIsSupported() {
 
 
 function testIs3dSupported() {
-  if (goog.userAgent.GECKO && !goog.userAgent.product.isVersion(10) ||
+  if (!goog.userAgent.product.isVersion(10) ||
       (goog.userAgent.IE && !goog.userAgent.product.isVersion(10))) {
     assertFalse(goog.style.transform.is3dSupported());
   } else {

--- a/closure/goog/style/transform_test.js
+++ b/closure/goog/style/transform_test.js
@@ -98,8 +98,7 @@ function testIsSupported() {
 
 
 function testIs3dSupported() {
-  if (!goog.userAgent.product.isVersion(10) ||
-      (goog.userAgent.IE && !goog.userAgent.product.isVersion(10))) {
+  if (goog.userAgent.IE && !goog.userAgent.product.isVersion(10)) {
     assertFalse(goog.style.transform.is3dSupported());
   } else {
     assertTrue(goog.style.transform.is3dSupported());


### PR DESCRIPTION
Currently the MatrixConstructor doesn't really work with Firefox, this fixes the issue.
