### PR TITLE
use markdown code block in comment of eventid

### DIFF
--- a/closure/goog/events/eventid.js
+++ b/closure/goog/events/eventid.js
@@ -18,15 +18,14 @@ goog.provide('goog.events.EventId');
 
 /**
  * A templated class that is used when registering for events. Typical usage:
- * <code>
- *   /** @type {goog.events.EventId<MyEventObj>}
- *   var myEventId = new goog.events.EventId(
+ *
+ *    /** @type {goog.events.EventId<MyEventObj>} *\
+ *    var myEventId = new goog.events.EventId(
  *       goog.events.getUniqueId(('someEvent'));
  *
- *   // No need to cast or declare here since the compiler knows the correct
- *   // type of 'evt' (MyEventObj).
- *   something.listen(myEventId, function(evt) {});
- * </code>
+ *    // No need to cast or declare here since the compiler knows the
+ *    // correct type of 'evt' (MyEventObj).
+ *    something.listen(myEventId, function(evt) {});
  *
  * @param {string} eventId
  * @template T


### PR DESCRIPTION
In `goog.events.eventid` the comment has sample code which includes text
that looks like an HTML tag.  The text is:

     /** @type {goog.events.EventId<MyEventObj>}

When building documentation with js-dossier, this comment generates
warnings:

     [WARNING][com.github.jsdossier.soy.HtmlSanitizer]
     Discarded tag "myeventobj" in text:

Change to use `&lt;` instead of `<` in that comment to prevent these
warnings. Additionally, use `<pre>` tags so that the `&lt;` is
interpreted correctly, and the line breaks are preserved. Further, add
the closing comment symbol * / to the code sample (with a space so it
doesn't actually close the comment block).