### PR TITLE
Changed name for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-closure-library",
+  "name": "closure-library",
   "description": "Google's common JavaScript library",
   "version": "20151015.0.0",
   "repository": {


### PR DESCRIPTION
Apps using the closure library usually refer to it as `closure-library/../../` etc. However, the name google-closure-library breaks this and there is currently [no way to alias it](https://github.com/npm/npm/issues/2943) within npm.