### PR TITLE
Re-enable cross origin XHR test now that IE is configured properly

### DIFF
--- a/closure/goog/labs/net/xhr_test.js
+++ b/closure/goog/labs/net/xhr_test.js
@@ -270,13 +270,6 @@ function testBadUrlDetectedAsError() {
 }
 
 function testBadOriginTriggersOnErrorHandler() {
-  // Disable tests when being run as a part of open-source. For some reason, the
-  // external Windows/IE VMs on Sauce Labs allow cross-origin requests.
-  // TODO(joeltine): Re-enable externally when cross-origin requests are
-  // properly blocked.
-  if (goog.userAgent.IE && /closure\/goog\/labs/.test(location.pathname)) {
-    return;
-  }
   return xhr.get('http://www.google.com').then(
       function() {
         fail('XHR to http://www.google.com should\'ve failed due to ' +


### PR DESCRIPTION
Fixed in https://github.com/google/closure-library/pull/607