### PR TITLE
change args type to ArrayLike

### DIFF
--- a/closure/goog/async/throttle.js
+++ b/closure/goog/async/throttle.js
@@ -69,7 +69,7 @@ goog.async.Throttle = function(listener, interval, opt_handler) {
 
   /**
    * The last arguments passed into {@code fire}.
-   * @private {!Array}
+   * @private {!goog.array.ArrayLike}
    */
   this.args_ = [];
 };


### PR DESCRIPTION
`args_` assignment on line 123 throws an annotation error since `arguments` is an `ArrayLike`. 