### PR TITLE
disable phantom timeout tests

### DIFF
--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -16,7 +16,9 @@ var IGNORED_TESTS = [
   'closure/goog/testing/multitestrunner_test.html',
   // These Promise-based tests all timeout for unknown reasons.
   // Disable for now.
-  'closure/goog/testing/fs/integration_test.html'
+  'closure/goog/testing/fs/integration_test.html',
+  'closure/goog/debug/fpsdisplay_test.html',
+  'closure/goog/net/jsloader_test.html'
 ];
 
 describe('Run all Closure unit tests', function() {

--- a/protractor_spec.js
+++ b/protractor_spec.js
@@ -13,7 +13,10 @@ var IGNORED_TESTS = [
   // Test hangs in IE8.
   'closure/goog/ui/plaintextspellchecker_test.html',
   // TODO(joeltine): Re-enable once fixed for external testing.
-  'closure/goog/testing/multitestrunner_test.html'
+  'closure/goog/testing/multitestrunner_test.html',
+  // These Promise-based tests all timeout for unknown reasons.
+  // Disable for now.
+  'closure/goog/testing/fs/integration_test.html'
 ];
 
 describe('Run all Closure unit tests', function() {


### PR DESCRIPTION
Some promise-based tests timeout randomly on Sauce/Travis.  Disable them for now to stabilize tests.

E.g., https://travis-ci.org/google/closure-library/builds/97510922

What's odd is that it says "[internet explorer 10.0 Windows 7 #4] Elapsed time: 14ms.", but the default timeout is 1s. 
