### PR TITLE
Remove two dead pages from demos

### DIFF
--- a/closure/goog/demos/index_nav.html
+++ b/closure/goog/demos/index_nav.html
@@ -113,7 +113,6 @@ See the COPYING file for details.
       {name: 'Graphics', childNodes: [
         {name: 'Basic Elements', url: 'graphics/basicelements.html'},
         {name: 'Events', url: 'graphics/events.html'},
-        {name: 'Imageless Rounded Corner', url: 'imagelessroundedcorner.html'},
         {name: 'Modify Elements', url: 'graphics/modifyelements.html'},
         {name: 'Tiger', url: 'graphics/tiger.html'}
       ]},
@@ -130,7 +129,6 @@ See the COPYING file for details.
       ]},
       {name: 'JSON Pretty Printer', url: 'jsonprettyprinter.html'},
       {name: 'Label Input', url: 'labelinput.html'},
-      {name: 'Offline UI', url: 'offline.html'},
       {name: 'Pixel Density Monitor', url: 'pixeldensitymonitor.html'},
       {name: 'Plain Text Spell Checker', url: 'plaintextspellchecker.html'},
       {name: 'Popup', url: 'popup.html'},


### PR DESCRIPTION
The Imageless Rounded Corder and Offline UI demo pages are included
in the demo page index but are not available - they lead to 404
errors. They describe functionality that has been removed from Closure
long ago.

The offline page was removed when goog.gears was removed from Closure in
7e9ce0ac84cc013055f5575b85b3147e046bbff2

The RoundedCorder demo page was removed in
1ab0fa8dff33aa92c384838edc918f47b68bbe6e
and in both cases the index was not modified.