### PR TITLE
Fix test param types

### DIFF
--- a/closure/goog/editor/plugins/basictextformatter_test.js
+++ b/closure/goog/editor/plugins/basictextformatter_test.js
@@ -716,7 +716,7 @@ function testFontSizeDoesntOverrideStyleAttrMultiNode() {
  * tag, sometimes it wraps the span with the font tag. Either one is ok as
  * long as a font tag is actually being used instead of just modifying the
  * span's style, because our fix for {@bug 1286408} would remove that style.
- * @param {function} doSelect Function to select the "23" text in the test
+ * @param {function()} doSelect Function to select the "23" text in the test
  *     content.
  */
 function doTestFontSizeStyledSpan(doSelect) {

--- a/closure/goog/useragent/product_test.js
+++ b/closure/goog/useragent/product_test.js
@@ -94,7 +94,7 @@ function assertBrowserAndVersion(userAgent, browser, version) {
  * @param {Array<{
  *           ua: string,
  *           versions: Array<{
- *             num: {string|number}, truth: boolean}>}>} userAgents
+ *             num: (string|number), truth: boolean}>}>} userAgents
  * @param {string} browser
  */
 function checkEachUserAgentDetected(userAgents, browser) {


### PR DESCRIPTION
Minor fixes in unit test, where the param annotation is wrong.