### PR TITLE
Removed use of octal notation in tests.

### DIFF
--- a/closure/goog/date/date_test.js
+++ b/closure/goog/date/date_test.js
@@ -222,7 +222,7 @@ function testGetWeekNumber() {
   assertEquals('2008-12-29 is in week 1 of the following year', 1,
                f(2008, goog.date.month.DEC, 29));
   assertEquals('2010-01-03 is in week 53 of the previous year', 53,
-               f(2010, goog.date.month.JAN, 03));
+               f(2010, goog.date.month.JAN, 3));
 
   assertEquals('2008-02-01 is in week 5', 5,
                f(2008, goog.date.month.FEB, 1));
@@ -1143,10 +1143,10 @@ function testIsDateLikeWithGoogDateTime() {
 
 
 function testDateTimezone() {
-  var d = new goog.date.DateTime(2006, 01, 01, 12, 00, 00);
+  var d = new goog.date.DateTime(2006, 1, 1, 12, 0, 0);
   d.add(new goog.date.Interval(goog.date.Interval.MINUTES,
                                d.getTimezoneOffset()));
-  var d2 = new goog.date.DateTime(2006, 01, 01, 12, 00, 00);
+  var d2 = new goog.date.DateTime(2006, 1, 1, 12, 0, 0);
   assertEquals('Compensate for timezone and compare with UTC date/time',
                d.toIsoString(true), d2.toUTCIsoString(true));
 }
@@ -1379,7 +1379,7 @@ function testDateCompare() {
       goog.date.Date.compare(
           new goog.date.DateTime(1982, goog.date.month.MAR, 12, 6, 48, 32, 354),
           new goog.date.DateTime(
-              1982, goog.date.month.MAR, 12, 12, 07, 21, 832)));
+              1982, goog.date.month.MAR, 12, 12, 7, 21, 832)));
 
   // Test dates before the year 0.  Dates are Talk Like a Pirate Day, and
   // Towel Day, 300 B.C. (and before pirates).

--- a/closure/goog/date/daterange_test.js
+++ b/closure/goog/date/daterange_test.js
@@ -212,7 +212,7 @@ function testLastBusinessWeek() {
 }
 
 function testAllTime() {
-  var s = new gd(0000, 0, 1);
+  var s = new gd(0, 0, 1);
   var e = new gd(9999, 11, 31);
   assertStartEnd('allTime', s, e, gdr.allTime());
   assertStartEnd('allTime by key', s, e,

--- a/closure/goog/i18n/datetimeformat_test.js
+++ b/closure/goog/i18n/datetimeformat_test.js
@@ -361,7 +361,7 @@ function testFractionalSeconds() {
 function testPredefinedFormatter() {
   goog.i18n.DateTimePatterns = goog.i18n.DateTimePatterns_de;
   goog.i18n.DateTimeSymbols = goog.i18n.DateTimeSymbols_de;
-  date = new Date(2006, 7, 4, 13, 49, 24, 000);
+  date = new Date(2006, 7, 4, 13, 49, 24, 0);
   var fmt = new goog.i18n.DateTimeFormat(
       goog.i18n.DateTimeFormat.Format.FULL_DATE);
   assertEquals('Freitag, 4. August 2006', fmt.format(date));
@@ -581,10 +581,10 @@ function test_daylightTimeTransition() {
   var date = new Date(Date.UTC(2006, 4 - 1, 2, 9, 59, 0));
   var fmt = new goog.i18n.DateTimeFormat('MM/dd/yyyy HH:mm:ss z');
   assertEquals('04/02/2006 01:59:00 PST', fmt.format(date, timeZone));
-  date = new Date(Date.UTC(2006, 4 - 1, 2, 10, 01, 0));
+  date = new Date(Date.UTC(2006, 4 - 1, 2, 10, 1, 0));
   fmt = new goog.i18n.DateTimeFormat('MM/dd/yyyy HH:mm:ss z');
   assertEquals('04/02/2006 03:01:00 PDT', fmt.format(date, timeZone));
-  date = new Date(Date.UTC(2006, 4 - 1, 2, 10, 00, 0));
+  date = new Date(Date.UTC(2006, 4 - 1, 2, 10, 0, 0));
   fmt = new goog.i18n.DateTimeFormat('MM/dd/yyyy HH:mm:ss z');
   assertEquals('04/02/2006 03:00:00 PDT', fmt.format(date, timeZone));
 }
@@ -614,7 +614,7 @@ function testTimeDisplayOnDaylightTimeTransitionDayChange() {
   goog.i18n.DateTimeSymbols = goog.i18n.DateTimeSymbols_de;
 
   // Time is 2015/11/01 3:00:01am after US PDT -> PST. 11:00:01am UTC.
-  var date = new Date(Date.UTC(2015, 11 - 1, 01, 11, 0, 1));
+  var date = new Date(Date.UTC(2015, 11 - 1, 1, 11, 0, 1));
   // Convert to GMT-12, across DST transition.
   // The date should also change, but does not change when subtracting 4 hours
   // from PST/PDT due to the extra hour from switching DST.


### PR DESCRIPTION
Removed the use of octals in tests. Produces a: "WARNING - This style of octal literal is not supported in strict mode." in latest compiler.