### PR TITLE
Remove clang format ignore stuff.

### DIFF
--- a/scripts/ci/check_code_format.sh
+++ b/scripts/ci/check_code_format.sh
@@ -3,9 +3,7 @@
 # Script to determine if .js files in Pull Request are properly formatted.
 # Exits with non 0 exit code if formatting is needed.
 
-FILES_TO_CHECK=$(git diff --name-only HEAD^ |
-    grep -E "\.js$" |
-    grep -v -f scripts/ci/clang_ignore.txt)
+FILES_TO_CHECK=$(git diff --name-only HEAD^ | grep -E "\.js$")
 
 if [ -z "${FILES_TO_CHECK}" ]; then
   echo "No .js files to check for formatting."

--- a/scripts/ci/clang_ignore.txt
+++ b/scripts/ci/clang_ignore.txt
@@ -1,9 +1,0 @@
-closure/goog/locale/defaultlocalenameconstants.js
-closure/goog/i18n/ordinalrules.js
-closure/goog/i18n/pluralrules.js
-closure/goog/i18n/datetimepatterns.js
-closure/goog/i18n/numberformatsymbols.js
-closure/goog/i18n/datetimesymbols.js
-closure/goog/i18n/compactnumberformatsymbols.js
-closure/goog/i18n/numberformatsymbolsext.js
-closure/goog/i18n/datetimepatternsext.js


### PR DESCRIPTION
 clang-format-diff.py respects "//clang-format off|on" comments.