### PR TITLE
Add custom clang-format binary to default $PATH on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ install:
 before_script:
   - ./scripts/http/simple_http_server.py 2> /dev/null & sleep 5
   - ./scripts/ci/sauce_connect.sh
+  # Ensure we point to the version of clang-format that we installed in
+  # install_closure_deps.sh. Travis has an older version on the $PATH and
+  # clang-format-diff.py invokes "clang-format" with no option of specifying
+  # a binary path.
+  - export PATH=$PWD/../clang/bin/:$PATH
 
 script:
   - ./scripts/ci/compile_closure.sh


### PR DESCRIPTION
 Travis has an older version of clang installed by default which has formatting differences with the internal version.