### PR TITLE
Fix two minor issues in tests for goog.array.binarySearch

### DIFF
--- a/closure/goog/array/array_test.js
+++ b/closure/goog/array/array_test.js
@@ -1039,7 +1039,7 @@ function testBinarySearch() {
   assertTrue('-900000 should not be found', pos < 0);
   assertEquals(
       '-900000 should have an insertion point of 0', 0, insertionPoint(pos));
-  pos = goog.array.binarySearch(d, '54255');
+  pos = goog.array.binarySearch(d, 54255);
   assertTrue('54255 should not be found', pos < 0);
   assertEquals(
       '54255 should have an insertion point of ' + (d.length), d.length,

--- a/closure/goog/array/array_test.js
+++ b/closure/goog/array/array_test.js
@@ -1067,8 +1067,8 @@ function testBinarySearch() {
       '-3 should be found at index 10', 10,
       goog.array.binarySearch(e, -3, revNumCompare));
   pos = goog.array.binarySearch(e, 0, revNumCompare);
-  assertTrue(
-      '0 should be found at index  || 10', pos == 7 || pos == 9 || pos == 10);
+  assertTrue('0 should be found at index 7 || 8 || 9',
+             pos == 7 || pos == 8 || pos == 9);
   pos = goog.array.binarySearch(e, 54254.1, revNumCompare);
   assertTrue('54254.1 should not be found', pos < 0);
   assertEquals(


### PR DESCRIPTION
This PR suggests to change two tests for `goog.array.binarySearch`:

* cb8112c96524b5dfa9493ab150406b5106913f41 suggests to pass a test argument as number not as string. All surrounding code passes numbers and if the reaction to a string argument was the target, a dedicated test should be better suited.
* e14e143f9b2fe7142cfb9bb58ade195f3c4883ff suggests to change the test expectations and message for an element that exists multiple times in the tested array. 

Please review.