### PR TITLE
Turkish currency is TRY not YTL

### DIFF
--- a/closure/goog/i18n/currency.js
+++ b/closure/goog/i18n/currency.js
@@ -320,7 +320,7 @@ goog.i18n.currency.CurrencyInfo = {
   'SEK': [50, 'kr', 'kr'],
   'SGD': [2, '$', 'S$'],
   'THB': [2, '\u0e3f', 'THB'],
-  'TRY': [2, 'TL', 'YTL'],
+  'TRY': [2, 'TL', 'TRY'],
   'TWD': [2, 'NT$', 'NT$'],
   'TZS': [0, 'TSh', 'TSh'],
   'UAH': [2, 'грн.', 'UAH'],


### PR DESCRIPTION
It fixes the Turkish currency name, ref: https://en.wikipedia.org/wiki/Turkish_lira (ISO 4217 code TRY (Numeric 949))