### PR TITLE
Disable the analyzer checks

### DIFF
--- a/scripts/ci/compile_closure.sh
+++ b/scripts/ci/compile_closure.sh
@@ -11,6 +11,7 @@ java -jar ../closure-compiler/build/compiler.jar \
   --jscomp_off=unnecessaryCasts \
   --jscomp_off=deprecated \
   --jscomp_off=lintChecks \
+  --jscomp_off=analyzerChecks \
   --js='**.js' \
   --js='!**_test.js' \
   --js='!**_perf.js' \


### PR DESCRIPTION
These are (much like the lint checks) not intended to be enabled as errors.