### PR TITLE
calcdeps: process new goog.module() and goog.require() syntax

### DIFF
--- a/closure/bin/calcdeps.py
+++ b/closure/bin/calcdeps.py
@@ -43,9 +43,8 @@ import subprocess
 import sys
 
 
-_BASE_REGEX_STRING = '^\s*goog\.%s\(\s*[\'"](.+)[\'"]\s*\)'
-req_regex = re.compile(_BASE_REGEX_STRING % 'require')
-prov_regex = re.compile(_BASE_REGEX_STRING % 'provide')
+req_regex = re.compile('^(?:[^=]+=)?\s*goog\.require\(\s*[\'"](.+)[\'"]\s*\)')
+prov_regex = re.compile('^\s*goog\.(?:provide|module)\(\s*[\'"](.+)[\'"]\s*\)')
 ns_regex = re.compile('^ns:((\w+\.)*(\w+))$')
 version_regex = re.compile('[\.0-9]+')
 


### PR DESCRIPTION
Update the regular expressions in calcdeps.py to support the new goog.module() and goog.require() syntax. Even though calcdeps.py is deprecated it is still used for generation of jsdeps files by users of closure compiler modules. Currently, neither closurebuilder.py nor the compiler's manifest file can meet this use case:

https://github.com/google/closure-compiler/issues/1474

As this change is small would you consider a one time update to the legacy tool?