### PR TITLE
fix type check issue in sha2 64bit

### DIFF
--- a/closure/goog/crypt/sha2_64bit.js
+++ b/closure/goog/crypt/sha2_64bit.js
@@ -174,7 +174,7 @@ goog.crypt.Sha2_64bit.prototype.update = function(message, opt_length) {
         chunkBytes = 0;
       }
     }
-  } else if (goog.isArray(message)) {
+  } else if (goog.isArrayLike(message)) {
     for (var i = 0; i < length; i++) {
       var b = message[i];
       // Hack:  b|0 coerces b to an integer, so the last part confirms that

--- a/closure/goog/crypt/sha2_64bit_test.js
+++ b/closure/goog/crypt/sha2_64bit_test.js
@@ -252,3 +252,26 @@ function testHasherNeedsReset_beforeUpdate() {
   hasher.digest();
   assertThrows('Need reset after digest', function() { hasher.update('abc'); });
 }
+
+function testHashingArrayLike() {
+  // Create array-like object
+  var obj = {};
+  obj.length = 26;
+  for (var i = 0; i < 26; i++) {
+    obj[i] = 97 + i;
+  }
+
+  assertTrue(goog.isArrayLike(obj));
+
+  // Check hashing
+  var hasher = new goog.crypt.Sha512();
+  hasher.update(obj);
+  var digest1 = hasher.digest();
+
+  hasher.reset();
+
+  hasher.update('abcdefghijklmnopqrstuvwxyz', 26);
+  var digest2 = hasher.digest();
+
+  assertElementsEquals(digest1, digest2);
+}


### PR DESCRIPTION
This is small fixes for `sha2_64bit.js`.
`message` in `update` might be an Array-Like object (e.g. Uint8Array).