### PR TITLE
Simplify IArrayLike|Array to IArrayLike

### DIFF
--- a/closure/goog/async/debouncer.js
+++ b/closure/goog/async/debouncer.js
@@ -91,7 +91,7 @@ goog.async.Debouncer = function(listener, interval, opt_handler) {
 
   /**
    * The last arguments passed into {@code fire}.
-   * @private {!Array|!IArrayLike}
+   * @private {!IArrayLike}
    */
   this.args_ = [];
 };

--- a/closure/goog/object/object.js
+++ b/closure/goog/object/object.js
@@ -238,7 +238,7 @@ goog.object.getKeys = function(obj) {
  * Example usage: getValueByKeys(jsonObj, 'foo', 'entries', 3)
  *
  * @param {!Object} obj An object to get the value from.  Can be array-like.
- * @param {...(string|number|!Array<number|string>|!IArrayLike<number|string>)}
+ * @param {...(string|number|!IArrayLike<number|string>)}
  *     var_args A number of keys
  *     (as strings, or numbers, for array-like objects).  Can also be
  *     specified as a single array of keys.


### PR DESCRIPTION
After https://github.com/google/closure-compiler/commit/9d52fed2c7da2a9e3807477c852c60b56edd2497,
Array implements IArrayLike, so the union types can be simplified.