### PR TITLE
Add "string" to return types of goog.array methods

### DIFF
--- a/closure/goog/array/array.js
+++ b/closure/goog/array/array.js
@@ -496,8 +496,8 @@ goog.array.count = function(arr, f, opt_obj) {
  *     for every element. This function takes 3 arguments (the element, the
  *     index and the array) and should return a boolean.
  * @param {S=} opt_obj An optional "this" context for the function.
- * @return {T|null} The first array element that passes the test, or null if no
- *     element is found.
+ * @return {T|string|null} The first array element that passes the test, or
+ *     null if no element is found.
  * @template T,S
  */
 goog.array.find = function(arr, f, opt_obj) {
@@ -542,8 +542,8 @@ goog.array.findIndex = function(arr, f, opt_obj) {
  *     takes 3 arguments (the element, the index and the array) and should
  *     return a boolean.
  * @param {S=} opt_obj An optional "this" context for the function.
- * @return {T|null} The last array element that passes the test, or null if no
- *     element is found.
+ * @return {T|string|null} The last array element that passes the test, or
+ *     null if no element is found.
  * @template T,S
  */
 goog.array.findRight = function(arr, f, opt_obj) {


### PR DESCRIPTION
Namely, goog.find and goog.array.findRight can also return strings.

Found by Closure Compiler's NTI.
