### PR TITLE
Allocate a new array for comparison in goog.array.stableSort

### DIFF
--- a/closure/goog/array/array.js
+++ b/closure/goog/array/array.js
@@ -1132,16 +1132,17 @@ goog.array.sort = function(arr, opt_compareFn) {
  * @template T
  */
 goog.array.stableSort = function(arr, opt_compareFn) {
+  var compArr = new Array(arr.length);
   for (var i = 0; i < arr.length; i++) {
-    arr[i] = {index: i, value: arr[i]};
+    compArr[i] = {index: i, value: arr[i]};
   }
   var valueCompareFn = opt_compareFn || goog.array.defaultCompare;
   function stableCompareFn(obj1, obj2) {
     return valueCompareFn(obj1.value, obj2.value) || obj1.index - obj2.index;
   }
-  goog.array.sort(arr, stableCompareFn);
+  goog.array.sort(compArr, stableCompareFn);
   for (var i = 0; i < arr.length; i++) {
-    arr[i] = arr[i].value;
+    arr[i] = compArr[i].value;
   }
 };
 


### PR DESCRIPTION
This fixes a couple of warnings found by Closure Compiler's NTI. It should also be more performant on V8 because it avoids modifying the memory layout of "arr"'s backing store.