### PR TITLE
Mark goog.dom.defaultDomHelper_ as {!goog.dom.DomHelper|undefined}.

### DIFF
--- a/closure/goog/dom/dom.js
+++ b/closure/goog/dom/dom.js
@@ -88,7 +88,7 @@ goog.dom.getDomHelper = function(opt_element) {
 
 /**
  * Cached default DOM helper.
- * @type {goog.dom.DomHelper}
+ * @type {!goog.dom.DomHelper|undefined}
  * @private
  */
 goog.dom.defaultDomHelper_;


### PR DESCRIPTION
This was caught by Closure Compiler's NTI.