### PR TITLE
Fix insertAll logic when heap is empty

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Anish Visaria <anishvisaria98@gmail.com>
 John Huân Vũ <jvu.calpoly@gmail.com>
 Peter Lu <peterlu83+github@gmail.com>
 Filipe Catraia <filipe.catraia@deliveryhero.com>
+Dan Rubalsky <drubalsky@plentakill.com>

--- a/closure/goog/structs/heap.js
+++ b/closure/goog/structs/heap.js
@@ -89,7 +89,7 @@ goog.structs.Heap.prototype.insertAll = function(heap) {
     // If it is a heap and the current heap is empty, I can rely on the fact
     // that the keys/values are in the correct order to put in the underlying
     // structure.
-    if (heap.getCount() <= 0) {
+    if (this.getCount() <= 0) {
       var nodes = this.nodes_;
       for (var i = 0; i < keys.length; i++) {
         nodes.push(new goog.structs.Node(keys[i], values[i]));

--- a/closure/goog/structs/heap_test.js
+++ b/closure/goog/structs/heap_test.js
@@ -19,67 +19,67 @@ goog.require('goog.structs');
 goog.require('goog.structs.Heap');
 goog.require('goog.testing.jsunit');
 
-function getHeap() {
-  var h = new goog.structs.Heap();
-  h.insert(0, 'a');
-  h.insert(1, 'b');
-  h.insert(2, 'c');
-  h.insert(3, 'd');
-  return h;
-}
 
-
-function getHeap2() {
+/**
+ * Constructs a heap from key-value pairs passed as arguments
+ * @param {...!Array} List of length 2 arrays [key, value] as arguments
+ * @returns {goog.structs.Heap} Heap constructed from passed in key-value pairs
+ */
+function makeHeap() {
   var h = new goog.structs.Heap();
-  h.insert(1, 'b');
-  h.insert(3, 'd');
-  h.insert(0, 'a');
-  h.insert(2, 'c');
+  var key, value;
+
+  for (var i = 0; i < arguments.length; i++) {
+    key = arguments[i][0];
+    value = arguments[i][1];
+    h.insert(key, value);
+  }
+
   return h;
 }
 
 
 function testGetCount1() {
-  var h = getHeap();
-  assertEquals('count, should be 4', h.getCount(), 4);
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
+  assertEquals('count, should be 4', 4, h.getCount());
   h.remove();
-  assertEquals('count, should be 3', h.getCount(), 3);
+  assertEquals('count, should be 3', 3, h.getCount());
 }
 
 function testGetCount2() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   h.remove();
   h.remove();
   h.remove();
   h.remove();
-  assertEquals('count, should be 0', h.getCount(), 0);
+  assertEquals('count, should be 0', 0, h.getCount());
 }
 
 
 function testKeys() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   var keys = h.getKeys();
   for (var i = 0; i < 4; i++) {
     assertTrue('getKeys, key ' + i + ' found', goog.structs.contains(keys, i));
   }
-  assertEquals('getKeys, Should be 4 keys', goog.structs.getCount(keys), 4);
+  assertEquals('getKeys, Should be 4 keys', 4, goog.structs.getCount(keys));
 }
 
 
 function testValues() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   var values = h.getValues();
 
   assertTrue('getKeys, value "a" found', goog.structs.contains(values, 'a'));
   assertTrue('getKeys, value "b" found', goog.structs.contains(values, 'b'));
   assertTrue('getKeys, value "c" found', goog.structs.contains(values, 'c'));
   assertTrue('getKeys, value "d" found', goog.structs.contains(values, 'd'));
-  assertEquals('getKeys, Should be 4 keys', goog.structs.getCount(values), 4);
+  assertEquals('getKeys, Should be 4 keys', 4, goog.structs.getCount(values));
 }
 
 
 function testContainsKey() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
 
   for (var i = 0; i < 4; i++) {
     assertTrue('containsKey, key ' + i + ' found', h.containsKey(i));
@@ -89,7 +89,7 @@ function testContainsKey() {
 
 
 function testContainsValue() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
 
   assertTrue('containsValue, value "a" found', h.containsValue('a'));
   assertTrue('containsValue, value "b" found', h.containsValue('b'));
@@ -100,7 +100,7 @@ function testContainsValue() {
 
 
 function testClone() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   var h2 = h.clone();
   assertTrue('clone so it should not be empty', !h2.isEmpty());
   assertTrue('clone so it should contain key 0', h2.containsKey(0));
@@ -109,14 +109,14 @@ function testClone() {
 
 
 function testClear() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   h.clear();
   assertTrue('cleared so it should be empty', h.isEmpty());
 }
 
 
 function testIsEmpty() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   assertFalse('4 values so should not be empty', h.isEmpty());
 
   h.remove();
@@ -130,86 +130,110 @@ function testIsEmpty() {
 
 
 function testPeek1() {
-  var h = getHeap();
-  assertEquals('peek, Should be "a"', h.peek(), 'a');
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
+  assertEquals('peek, Should be "a"', 'a', h.peek());
 }
 
 
 function testPeek2() {
-  var h = getHeap2();
-  assertEquals('peek, Should be "a"', h.peek(), 'a');
+  var h = makeHeap([1, 'b'], [3, 'd'], [0, 'a'], [2, 'c']);
+  assertEquals('peek, Should be "a"', 'a', h.peek());
 }
 
 
 function testPeek3() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   h.clear();
-  assertEquals('peek, Should be "undefined"', h.peek(), undefined);
+  assertEquals('peek, Should be "undefined"', undefined, h.peek());
 }
 
 
 function testPeekKey1() {
-  var h = getHeap();
-  assertEquals('peekKey, Should be "0"', h.peekKey(), 0);
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
+  assertEquals('peekKey, Should be "0"', 0, h.peekKey());
 }
 
 
 function testPeekKey2() {
-  var h = getHeap2();
-  assertEquals('peekKey, Should be "0"', h.peekKey(), 0);
+  var h = makeHeap([1, 'b'], [3, 'd'], [0, 'a'], [2, 'c']);
+  assertEquals('peekKey, Should be "0"', 0, h.peekKey());
 }
 
 
 function testPeekKey3() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
   h.clear();
-  assertEquals('peekKey, Should be "undefined"', h.peekKey(), undefined);
+  assertEquals('peekKey, Should be "undefined"', undefined, h.peekKey());
 }
 
 
 function testRemove1() {
-  var h = getHeap();
+  var h = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
 
-  assertEquals('remove, Should be "a"', h.remove(), 'a');
-  assertEquals('remove, Should be "b"', h.remove(), 'b');
-  assertEquals('remove, Should be "c"', h.remove(), 'c');
-  assertEquals('remove, Should be "d"', h.remove(), 'd');
+  assertEquals('remove, Should be "a"', 'a', h.remove());
+  assertEquals('remove, Should be "b"', 'b', h.remove());
+  assertEquals('remove, Should be "c"', 'c', h.remove());
+  assertEquals('remove, Should be "d"', 'd', h.remove());
 }
 
 
 function testRemove2() {
-  var h = getHeap2();
+  var h = makeHeap([1, 'b'], [3, 'd'], [0, 'a'], [2, 'c']);
 
-  assertEquals('remove, Should be "a"', h.remove(), 'a');
-  assertEquals('remove, Should be "b"', h.remove(), 'b');
-  assertEquals('remove, Should be "c"', h.remove(), 'c');
-  assertEquals('remove, Should be "d"', h.remove(), 'd');
+  assertEquals('remove, Should be "a"', 'a', h.remove());
+  assertEquals('remove, Should be "b"', 'b', h.remove());
+  assertEquals('remove, Should be "c"', 'c', h.remove());
+  assertEquals('remove, Should be "d"', 'd', h.remove());
 }
 
 
 function testInsertPeek1() {
-  var h = new goog.structs.Heap();
+  var h = makeHeap();
 
   h.insert(3, 'd');
-  assertEquals('peek, Should be "d"', h.peek(), 'd');
+  assertEquals('peek, Should be "d"', 'd', h.peek());
   h.insert(2, 'c');
-  assertEquals('peek, Should be "c"', h.peek(), 'c');
+  assertEquals('peek, Should be "c"', 'c', h.peek());
   h.insert(1, 'b');
-  assertEquals('peek, Should be "b"', h.peek(), 'b');
+  assertEquals('peek, Should be "b"', 'b', h.peek());
   h.insert(0, 'a');
-  assertEquals('peek, Should be "a"', h.peek(), 'a');
+  assertEquals('peek, Should be "a"', 'a', h.peek());
 }
 
 
 function testInsertPeek2() {
-  var h = new goog.structs.Heap();
+  var h = makeHeap();
 
   h.insert(1, 'b');
-  assertEquals('peak, Should be "b"', h.peek(), 'b');
+  assertEquals('peek, Should be "b"', 'b', h.peek());
   h.insert(3, 'd');
-  assertEquals('peak, Should be "b"', h.peek(), 'b');
+  assertEquals('peek, Should be "b"', 'b', h.peek());
   h.insert(0, 'a');
-  assertEquals('peak, Should be "a"', h.peek(), 'a');
+  assertEquals('peek, Should be "a"', 'a', h.peek());
   h.insert(2, 'c');
-  assertEquals('peak, Should be "a"', h.peek(), 'a');
+  assertEquals('peek, Should be "a"', 'a', h.peek());
+}
+
+function testInsertAllPeek1() {
+  var h1 = makeHeap([1, 'e']);
+  var h2 = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
+
+  h1.insertAll(h2);
+  assertEquals('peek, should be "a"', 'a', h1.peek());
+}
+
+function testInsertAllPeek2() {
+  var h1 = makeHeap([-1, 'z']);
+  var h2 = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
+
+  h1.insertAll(h2);
+  assertEquals('peek, should be "z"', 'z', h1.peek());
+}
+
+function testInsertAllPeek3() {
+  var h1 = makeHeap();
+  var h2 = makeHeap([0, 'a'], [1, 'b'], [2, 'c'], [3, 'd']);
+
+  h1.insertAll(h2);
+  assertEquals('peek, should be "a"', 'a', h1.peek());
 }


### PR DESCRIPTION
Fixed logic for insertAll into empty heap, added insertAll test cases, fixed parameter order of assertEquals calls in heap tests