### PR TITLE
Remove redundant boolean casts.

### DIFF
--- a/closure/goog/fx/animation.js
+++ b/closure/goog/fx/animation.js
@@ -291,7 +291,7 @@ goog.fx.Animation.prototype.stop = function(opt_gotoEnd) {
   goog.fx.anim.unregisterAnimation(this);
   this.setStateStopped();
 
-  if (!!opt_gotoEnd) {
+  if (opt_gotoEnd) {
     this.progress = 1;
   }
 

--- a/closure/goog/net/xpc/crosspagechannel.js
+++ b/closure/goog/net/xpc/crosspagechannel.js
@@ -276,7 +276,7 @@ goog.net.xpc.CrossPageChannel.prototype.isPeerAvailable = function() {
   // when querying its parent's 'closed' status. Note that this is a different
   // case than mibuerge@'s note above.
   try {
-    return !!this.peerWindowObject_ && !Boolean(this.peerWindowObject_.closed);
+    return !!this.peerWindowObject_ && !this.peerWindowObject_.closed;
   } catch (e) {
     // If the window is closing, an error may be thrown.
     return false;

--- a/closure/goog/ui/tree/typeahead.js
+++ b/closure/goog/ui/tree/typeahead.js
@@ -198,7 +198,7 @@ goog.ui.tree.TypeAhead.prototype.removeNodeFromMap = function(node) {
     if (nodeList) {
       // Remove the node from the array.
       goog.array.remove(nodeList, node);
-      if (!!nodeList.length) {
+      if (nodeList.length) {
         this.nodeMap_.remove(labelText);
       }
     }

--- a/third_party/closure/goog/caja/string/html/htmlparser.js
+++ b/third_party/closure/goog/caja/string/html/htmlparser.js
@@ -488,8 +488,7 @@ goog.string.html.HtmlParser.prototype.lookupEntity_ = function(name) {
   var m = name.match(goog.string.html.HtmlParser.DECIMAL_ESCAPE_RE_);
   if (m) {
     return String.fromCharCode(parseInt(m[1], 10));
-  } else if (
-      !!(m = name.match(goog.string.html.HtmlParser.HEX_ESCAPE_RE_))) {
+  } else if (m = name.match(goog.string.html.HtmlParser.HEX_ESCAPE_RE_)) {
     return String.fromCharCode(parseInt(m[1], 16));
   }
   return '';

--- a/third_party/closure/goog/dojo/dom/query.js
+++ b/third_party/closure/goog/dojo/dom/query.js
@@ -211,9 +211,8 @@ goog.dom.query = (function() {
 
   // On browsers that support the "children" collection we can avoid a lot of
   // iteration on chaff (non-element) nodes.
-  var childNodesName = !!goog.dom.getDocument().firstChild['children'] ?
-                          'children' :
-                          'childNodes';
+  var childNodesName =
+      goog.dom.getDocument().firstChild['children'] ? 'children' : 'childNodes';
 
   var specials = '>~+';
 


### PR DESCRIPTION
These were caught by the lint check I'm proposing in https://github.com/google/closure-compiler/pull/1570.