### PR TITLE
Fix a few more lint warnings.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ John Huân Vũ <jvu.calpoly@gmail.com>
 Peter Lu <peterlu83+github@gmail.com>
 Filipe Catraia <filipe.catraia@deliveryhero.com>
 Dan Rubalsky <drubalsky@plentakill.com>
+Michael Zhou <zhoumotongxue008@gmail.com>

--- a/closure/goog/proto2/test.pb.js
+++ b/closure/goog/proto2/test.pb.js
@@ -19,12 +19,12 @@
  */
 
 goog.provide('proto2.TestAllTypes');
+goog.provide('proto2.TestAllTypes.NestedEnum');
 goog.provide('proto2.TestAllTypes.NestedMessage');
 goog.provide('proto2.TestAllTypes.OptionalGroup');
 goog.provide('proto2.TestAllTypes.RepeatedGroup');
-goog.provide('proto2.TestAllTypes.NestedEnum');
-goog.provide('proto2.TestDefaultParent');
 goog.provide('proto2.TestDefaultChild');
+goog.provide('proto2.TestDefaultParent');
 goog.setTestOnly('proto2.TestAllTypes');
 
 goog.require('goog.proto2.Message');
@@ -3130,7 +3130,7 @@ proto2.TestAllTypes.prototype.clearPackedBool = function() {
  */
 proto2.TestAllTypes.NestedEnum = {
   FOO: 0,
-  OOF: 0,
+  OOF: 1,
   BAR: 2,
   BAZ: 3
 };

--- a/closure/goog/soy/soy_testhelper.js
+++ b/closure/goog/soy/soy_testhelper.js
@@ -51,8 +51,16 @@ function SanitizedContentSubclass(content, kind) {
 goog.inherits(SanitizedContentSubclass, goog.soy.data.SanitizedContent);
 
 
+/**
+ * @param {string} content The text.
+ * @param {goog.soy.data.SanitizedContentKind|string} kind The kind of safe
+ *     content.
+ * @return {!SanitizedContentSubclass}
+ */
 function makeSanitizedContent(content, kind) {
-  return new SanitizedContentSubclass(content, kind);
+  return new SanitizedContentSubclass(
+      content,
+      /** @type {goog.soy.data.SanitizedContentKind} */ (kind));
 }
 
 
@@ -64,44 +72,79 @@ function makeSanitizedContent(content, kind) {
 var example = {};
 
 
-example.textNodeTemplate = function(opt_data, opt_sb, opt_injectedData) {
-  assertNotNull(opt_data);
-  assertNotUndefined(opt_data);
-  return goog.string.htmlEscape(opt_data.name);
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.textNodeTemplate = function(data, opt_sb, opt_injectedData) {
+  assertNotNull(data);
+  assertNotUndefined(data);
+  return goog.string.htmlEscape(data.name);
 };
 
 
-example.singleRootTemplate = function(opt_data, opt_sb, opt_injectedData) {
-  assertNotNull(opt_data);
-  assertNotUndefined(opt_data);
-  return '<span>' + goog.string.htmlEscape(opt_data.name) + '</span>';
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.singleRootTemplate = function(data, opt_sb, opt_injectedData) {
+  assertNotNull(data);
+  assertNotUndefined(data);
+  return '<span>' + goog.string.htmlEscape(data.name) + '</span>';
 };
 
 
-example.multiRootTemplate = function(opt_data, opt_sb, opt_injectedData) {
-  assertNotNull(opt_data);
-  assertNotUndefined(opt_data);
-  return '<div>Hello</div><div>' + goog.string.htmlEscape(opt_data.name) +
-      '</div>';
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.multiRootTemplate = function(data, opt_sb, opt_injectedData) {
+  assertNotNull(data);
+  assertNotUndefined(data);
+  return '<div>Hello</div><div>' + goog.string.htmlEscape(data.name) + '</div>';
 };
 
 
-example.injectedDataTemplate = function(opt_data, opt_sb, opt_injectedData) {
-  assertNotNull(opt_data);
-  assertNotUndefined(opt_data);
-  return goog.string.htmlEscape(opt_data.name) +
-      goog.string.htmlEscape(opt_injectedData.name);
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.injectedDataTemplate = function(data, opt_sb, opt_injectedData) {
+  assertNotNull(data);
+  assertNotUndefined(data);
+  return goog.string.htmlEscape(data.name) +
+         goog.string.htmlEscape(opt_injectedData.name);
 };
 
 
-example.noDataTemplate = function(opt_data, opt_sb, opt_injectedData) {
-  assertNotNull(opt_data);
-  assertNotUndefined(opt_data);
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.noDataTemplate = function(data, opt_sb, opt_injectedData) {
+  assertNotNull(data);
+  assertNotUndefined(data);
   return '<div>Hello</div>';
 };
 
 
-example.sanitizedHtmlTemplate = function(opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {!SanitizedContentSubclass}
+ */
+example.sanitizedHtmlTemplate = function(data, opt_sb, opt_injectedData) {
   // Test the SanitizedContent constructor.
   var sanitized = makeSanitizedContent(
       'Hello <b>World</b>', goog.soy.data.SanitizedContentKind.HTML);
@@ -110,27 +153,51 @@ example.sanitizedHtmlTemplate = function(opt_data, opt_sb, opt_injectedData) {
 };
 
 
-example.sanitizedHtmlAttributesTemplate = function(
-    opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {!SanitizedContentSubclass}
+ */
+example.sanitizedHtmlAttributesTemplate = function(data, opt_sb,
+                                                   opt_injectedData) {
   return makeSanitizedContent(
       'foo="bar"', goog.soy.data.SanitizedContentKind.ATTRIBUTES);
 };
 
 
-example.sanitizedCssTemplate = function(opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {!SanitizedContentSubclass}
+ */
+example.sanitizedCssTemplate = function(data, opt_sb, opt_injectedData) {
   return makeSanitizedContent(
       'display:none', goog.soy.data.SanitizedContentKind.CSS);
 };
 
 
-example.unsanitizedTextTemplate = function(opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {!SanitizedContentSubclass}
+ */
+example.unsanitizedTextTemplate = function(data, opt_sb, opt_injectedData) {
   return makeSanitizedContent(
       'I <3 Puppies & Kittens', goog.soy.data.SanitizedContentKind.TEXT);
 };
 
 
-example.templateSpoofingSanitizedContentString = function(
-    opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {!SanitizedContentSubclass}
+ */
+example.templateSpoofingSanitizedContentString = function(data, opt_sb,
+                                                          opt_injectedData) {
   return makeSanitizedContent(
       'Hello World',
       // This is to ensure we're using triple-equals against a unique Javascript
@@ -140,12 +207,24 @@ example.templateSpoofingSanitizedContentString = function(
 };
 
 
-example.tableRowTemplate = function(opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.tableRowTemplate = function(data, opt_sb, opt_injectedData) {
   return '<tr><td></td></tr>';
 };
 
 
-example.colGroupTemplateCaps = function(opt_data, opt_sb, opt_injectedData) {
+/**
+ * @param {{name: string}} data
+ * @param {null=} opt_sb
+ * @param {Object<string, *>=} opt_injectedData
+ * @return {string}
+ */
+example.colGroupTemplateCaps = function(data, opt_sb, opt_injectedData) {
   return '<COLGROUP></COLGROUP>';
 };
 


### PR DESCRIPTION
Fix goog.provide()'s that were not sorted alphabetically in closure/goog/proto2/test.pb.js.

Add missing JSDoc to functions in closure/goog/soy/soy_testhelper.js.
