### PR TITLE
Add var for extraRequire

### DIFF
--- a/closure/goog/test_module.js
+++ b/closure/goog/test_module.js
@@ -22,7 +22,7 @@ goog.module.declareLegacyNamespace();
 
 
 /** @suppress {extraRequire} */
-goog.require('goog.test_module_dep');
+var testModuleDep = goog.require('goog.test_module_dep');
 
 
 


### PR DESCRIPTION
works around compiler error:

```
compiler: ./closure/goog/test_module.js:25: ERROR - required "goog.test_module_dep" namespace never provided
goog.require('goog.test_module_dep');
```