### PR TITLE
Add goog.reflect.objectProperty

### DIFF
--- a/closure/goog/reflect/reflect.js
+++ b/closure/goog/reflect/reflect.js
@@ -37,6 +37,26 @@ goog.reflect.object = function(type, object) {
   return object;
 };
 
+/**
+ * Syntax for renaming property strings.
+ * @see http://go/jscompiler-renaming
+ * @see https://goo.gl/CRs09P
+ *
+ * Use this if you have an need to access a property as a string, but want
+ * to also have the property renamed by the compiler. In contrast to
+ * goog.reflect.object, this method takes an instance of an object.
+ *
+ * Properties must not be qualified names - only single property references
+ * are supported.
+ *
+ * @param {string} prop Name of the property
+ * @param {Object} object Instance of the object whose type will be used
+ *        for renaming
+ * @return {string} The renamed property.
+ */
+goog.reflect.objectProperty = function(prop, object) {
+  return prop;
+};
 
 /**
  * To assert to the compiler that an operation is needed when it would


### PR DESCRIPTION
Adds the definition for a new compiler primitive to support property renaming. Similar to `JSCompiler_renameProperty`, this method allows referencing a property by a string, but still allows renaming.

The second argument is the object which has the property. The object is used to determine type information to support type-based property renaming.

Requries google/closure-compiler#1754

CC @concavelenz 