### PR TITLE
xhrio no longer set xhr_.withCredentials if the value of withCredenti…

### DIFF
--- a/closure/goog/net/xhrio.js
+++ b/closure/goog/net/xhrio.js
@@ -587,8 +587,11 @@ goog.net.XhrIo.prototype.send = function(
   if (this.responseType_) {
     this.xhr_.responseType = this.responseType_;
   }
-
-  if (goog.object.containsKey(this.xhr_, 'withCredentials')) {
+  // Set xhr_.withCredentials only when the value is different, or else in 
+  // synchronous XMLHtppRequest.open Firefox will throw an exception.
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=736340
+  if (goog.object.containsKey(this.xhr_, 'withCredentials') &&
+	  this.xhr_.withCredentials !== this.withCredentials_) {
     this.xhr_.withCredentials = this.withCredentials_;
   }
 

--- a/closure/goog/net/xhrio.js
+++ b/closure/goog/net/xhrio.js
@@ -587,11 +587,11 @@ goog.net.XhrIo.prototype.send = function(
   if (this.responseType_) {
     this.xhr_.responseType = this.responseType_;
   }
-  // Set xhr_.withCredentials only when the value is different, or else in 
+  // Set xhr_.withCredentials only when the value is different, or else in
   // synchronous XMLHtppRequest.open Firefox will throw an exception.
   // https://bugzilla.mozilla.org/show_bug.cgi?id=736340
   if (goog.object.containsKey(this.xhr_, 'withCredentials') &&
-	  this.xhr_.withCredentials !== this.withCredentials_) {
+      this.xhr_.withCredentials !== this.withCredentials_) {
     this.xhr_.withCredentials = this.withCredentials_;
   }
 


### PR DESCRIPTION
Refer to:
https://github.com/google/closure-library/issues/702 

Copy of message:
XhrIo withCredentials on Firefox using synchronous XMLHtppRequest.open will always throw an error due to Xhrio.js setting withCredentials to false no matter what

Explanation of the thrown error can be found here: https://bugzilla.mozilla.org/show_bug.cgi?id=736340

Xhrio.js contains this bit of problematic code in the method 
```
goog.net.XhrIo.prototype.send = function() ...: 
[...]
  if (goog.object.containsKey(this.xhr_, 'withCredentials')) {
    this.xhr_.withCredentials = this.withCredentials_;
  }
[...]
```
A quick solution could be to test if this.widthCredentials_ is something else then false.

How to reproduce:
```
goog.provide('fusionmd.SyncXmlHttpFactory');
goog.require('goog.net.DefaultXmlHttpFactory');

/**
* An XML HTTP factory that creates synchronous XHRs regardless of which option
* (sync/async) is actually used. The factory overcomes the Closure Library
* limitation that only asynchronous XHRs are created.
* 
* var syncXhr = new goog.net.XhrIo(new fusionmd.SyncXmlHttpFactory());
*
* @constructor
* @extends {goog.net.DefaultXmlHttpFactory}
*/
fusionmd.SyncXmlHttpFactory = function() {
    goog.base(this);
};
goog.inherits(fusionmd.SyncXmlHttpFactory, goog.net.DefaultXmlHttpFactory);

/**
* Always opens a synchronous XHR.
*
* @this {!XMLHttpRequest}
* @param {string} method
* @param {string} url
* @private
*/
fusionmd.SyncXmlHttpFactory.syncXhrOpen_ = function(method, url) {
    // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#open()
    /*async
An optional boolean parameter, defaulting to true, indicating whether or not to perform the operation asynchronously. If this value is false, the send()method does not return until the response is received. If true, notification of a completed transaction is provided using event listeners. This must be true if the multipart attribute is true, or an exception will be thrown.
Note: Starting with Gecko 30.0 (Firefox 30.0 / Thunderbird 30.0 / SeaMonkey 2.27), synchronous requests on the main thread have been deprecated due to the negative effects to the user experience.*/
    
    XMLHttpRequest.prototype.open.call(this, method, url, false);
};

/** @override */
fusionmd.SyncXmlHttpFactory.prototype.createInstance = function() {
    var instance;

    instance = goog.base(this, 'createInstance');
    instance.open = fusionmd.SyncXmlHttpFactory.syncXhrOpen_;
    return instance;
};
```


Then:
```
 // ping the online handler service synchronously to set connection status
    var syncXhr = new goog.net.XhrIo(new fusionmd.SyncXmlHttpFactory());
    syncXhr.send("/yourRestCall");
    this.isOnline_ = syncXhr.isSuccess();
```



