### PR TITLE
Remove use of CSSMatrix constructor.

### DIFF
--- a/closure/goog/style/transform.js
+++ b/closure/goog/style/transform.js
@@ -164,8 +164,5 @@ goog.style.transform.matrixConstructor_ =
       if (goog.isDef(goog.global['MSCSSMatrix'])) {
         return goog.global['MSCSSMatrix'];
       }
-      if (goog.isDef(goog.global['CSSMatrix'])) {
-        return goog.global['CSSMatrix'];
-      }
       return null;
     });


### PR DESCRIPTION
CSSMatrix was a non-standardized constructor that was briefly slated for inclusion in CSS Transitions Level 3 (see https://developer.mozilla.org/en-US/docs/Web/API/CSSMatrix). No current browser ships CSSMatrix (Chrome & Safari ship WebKitCSSMatrix, IE & Edge ship MSCSSMatrix).

The CSS Houdini TypedOM specification (https://www.w3.org/TR/css-typed-om-1/) has introduced CSSMatrix as a CSSTransformComponent constructor (https://www.w3.org/TR/css-typed-om-1/#cssmatrix) and support is in the process of being added to the Blink renderer.

This means that, right now, if Chrome is executed with experimental web platform features switched on, sites that attempt to use the CSSMatrix constructor through closure do not work correctly.

This patch should resolve that issue - site can continue to use the existing WebKitCSSMatrix or MSCSSMatrix constructors, and the new CSSMatrix object won't be invoked.
