### PR TITLE
Fix failed scan es6 destructuring assignment import

### DIFF
--- a/closure/bin/build/source.py
+++ b/closure/bin/build/source.py
@@ -23,12 +23,15 @@ __author__ = 'nnaze@google.com'
 
 import codecs
 import re
+import sys
 
 _BASE_REGEX_STRING = r'^\s*goog\.%s\(\s*[\'"](.+)[\'"]\s*\)'
 _MODULE_REGEX = re.compile(_BASE_REGEX_STRING % 'module')
 _PROVIDE_REGEX = re.compile(_BASE_REGEX_STRING % 'provide')
 
-_REQUIRE_REGEX_STRING = (r'^\s*(?:(?:var|let|const)\s+[a-zA-Z_$][a-zA-Z0-9$_]*'
+_SYMBOL_REGEX_STRING = r'[a-zA-Z_$][a-zA-Z0-9$_]*'
+_REQUIRE_REGEX_STRING = (r'^\s*(?:(?:var|let|const)\s+{?' + _SYMBOL_REGEX_STRING + 
+                         '(?:\s*,\s*' + _SYMBOL_REGEX_STRING + ')*}?'
                          r'\s*=\s*)?goog\.require\(\s*[\'"](.+)[\'"]\s*\)')
 _REQUIRES_REGEX = re.compile(_REQUIRE_REGEX_STRING)
 

--- a/closure/bin/build/source_test.py
+++ b/closure/bin/build/source_test.py
@@ -57,7 +57,7 @@ class SourceTestCase(unittest.TestCase):
 
     self.assertEqual(set(['foo']),
                      test_source.provides)
-    self.assertEqual(set(['bar']),
+    self.assertEqual(set(['bar', 'foo', 'foobar']),
                      test_source.requires)
     self.assertTrue(test_source.is_goog_module)
 
@@ -89,6 +89,8 @@ class SourceTestCase(unittest.TestCase):
 _TEST_MODULE_SOURCE = """
 goog.module('foo');
 var b = goog.require('bar');
+const {foo} = goog.require('foo');
+const {a, b} = goog.require('foobar');
 """
 
 


### PR DESCRIPTION
depswriter.py support scans code like:

const {A, B} = goog.require('some.goog.module');
