### PR TITLE
Fix linter path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Peter Lu <peterlu83+github@gmail.com>
 Filipe Catraia <filipe.catraia@deliveryhero.com>
 Dan Rubalsky <drubalsky@plentakill.com>
 Michael Zhou <zhoumotongxue008@gmail.com>
+mash <mashedcode@users.noreply.github.com>

--- a/closure/goog/dom/dom.js
+++ b/closure/goog/dom/dom.js
@@ -2238,8 +2238,8 @@ goog.dom.getPixelRatio = function() {
   } else if (win.matchMedia) {
     // Should be for IE10 and FF6-17 (this basically clamps to lower)
     return goog.dom.matchesPixelRatio_(3) || goog.dom.matchesPixelRatio_(2) ||
-        goog.dom.matchesPixelRatio_(1.5) || goog.dom.matchesPixelRatio_(1) ||
-        .75;
+           goog.dom.matchesPixelRatio_(1.5) || goog.dom.matchesPixelRatio_(1) ||
+           .75;
   }
   return 1;
 };
@@ -2261,13 +2261,13 @@ goog.dom.matchesPixelRatio_ = function(pixelRatio) {
    */
   var dpiPerDppx = 96;
   var query =
-       // FF16-17
-       '(min-resolution: ' + pixelRatio + 'dppx),' +
-       // FF6-15
-       '(min--moz-device-pixel-ratio: ' + pixelRatio + '),' +
-       // IE10 (this also works for two browsers above too but I don't want to
-       // trust the 1:96 fixed ratio magic.
-       '(min-resolution: ' + (pixelRatio * dpiPerDppx) + 'dpi)';
+      // FF16-17
+      '(min-resolution: ' + pixelRatio + 'dppx),' +
+      // FF6-15
+      '(min--moz-device-pixel-ratio: ' + pixelRatio + '),' +
+      // IE10 (this also works for two browsers above too but I don't want to
+      // trust the 1:96 fixed ratio magic.
+      '(min-resolution: ' + (pixelRatio * dpiPerDppx) + 'dpi)';
   return win.matchMedia(query).matches ? pixelRatio : 0;
 };
 

--- a/closure/goog/dom/dom.js
+++ b/closure/goog/dom/dom.js
@@ -2236,9 +2236,10 @@ goog.dom.getPixelRatio = function() {
   if (goog.isDef(win.devicePixelRatio)) {
     return win.devicePixelRatio;
   } else if (win.matchMedia) {
-    return goog.dom.matchesPixelRatio_(.75) ||
-        goog.dom.matchesPixelRatio_(1.5) || goog.dom.matchesPixelRatio_(2) ||
-        goog.dom.matchesPixelRatio_(3) || 1;
+    // Should be for IE10 and FF6-17
+    return goog.dom.matchesPixelRatio_(3) || goog.dom.matchesPixelRatio_(2) ||
+        goog.dom.matchesPixelRatio_(1.5) || goog.dom.matchesPixelRatio_(1) ||
+        .75;
   }
   return 1;
 };

--- a/closure/goog/dom/dom.js
+++ b/closure/goog/dom/dom.js
@@ -2236,7 +2236,7 @@ goog.dom.getPixelRatio = function() {
   if (goog.isDef(win.devicePixelRatio)) {
     return win.devicePixelRatio;
   } else if (win.matchMedia) {
-    // Should be for IE10 and FF6-17
+    // Should be for IE10 and FF6-17 (this basically clamps to lower)
     return goog.dom.matchesPixelRatio_(3) || goog.dom.matchesPixelRatio_(2) ||
         goog.dom.matchesPixelRatio_(1.5) || goog.dom.matchesPixelRatio_(1) ||
         .75;
@@ -2254,10 +2254,20 @@ goog.dom.getPixelRatio = function() {
  */
 goog.dom.matchesPixelRatio_ = function(pixelRatio) {
   var win = goog.dom.getWindow();
+  /**
+   * Due to the 1:96 fixed ratio of CSS in to CSS px, 1dppx is equivalent to
+   * 96dpi.
+   * @const {number}
+   */
+  var dpiPerDppx = 96;
   var query =
-      ('(-webkit-min-device-pixel-ratio: ' + pixelRatio + '),' +
+       // FF16-17
+       '(min-resolution: ' + pixelRatio + 'dppx),' +
+       // FF6-15
        '(min--moz-device-pixel-ratio: ' + pixelRatio + '),' +
-       '(min-resolution: ' + pixelRatio + 'dppx)');
+       // IE10 (this also works for two browsers above too but I don't want to
+       // trust the 1:96 fixed ratio magic.
+       '(min-resolution: ' + (pixelRatio * dpiPerDppx) + 'dpi)';
   return win.matchMedia(query).matches ? pixelRatio : 0;
 };
 

--- a/closure/goog/dom/dom_test.js
+++ b/closure/goog/dom/dom_test.js
@@ -1819,22 +1819,25 @@ function isIE8OrHigher() {
   return goog.userAgent.IE && goog.userAgent.product.isVersion('8');
 }
 
+function setWindow(win) {
+  stubs.set(goog.dom, 'getWindow', goog.functions.constant(win));
+}
 
 function testDevicePixelRatio() {
-  stubs.set(goog.dom, 'getWindow', goog.functions.constant({
-    matchMedia: function(query) { return {matches: query.indexOf('1.5') >= 0}; }
-  }));
+  var devicePixelRatio = 1.5;
+  setWindow({
+    'matchMedia': function(query) {
+      return {
+        'matches': devicePixelRatio >= parseFloat(query.split(': ')[1], 10)
+      };
+    }
+  });
 
-  stubs.set(goog.functions, 'CACHE_RETURN_VALUE', false);
+  assertEquals(devicePixelRatio, goog.dom.getPixelRatio());
 
-  assertEquals(goog.dom.getPixelRatio(), 1.5);
+  setWindow({'devicePixelRatio': 2.0});
+  assertEquals(2, goog.dom.getPixelRatio());
 
-  stubs.set(
-      goog.dom, 'getWindow', goog.functions.constant({devicePixelRatio: 2.0}));
-  goog.dom.devicePixelRatio_ = null;
-  assertEquals(goog.dom.getPixelRatio(), 2);
-
-  stubs.set(goog.dom, 'getWindow', goog.functions.constant({}));
-  goog.dom.devicePixelRatio_ = null;
-  assertEquals(goog.dom.getPixelRatio(), 1);
+  setWindow({});
+  assertEquals(1, goog.dom.getPixelRatio());
 }


### PR DESCRIPTION
Since the closure compiler moved from ant to maven the path to the linter has to be changed too.

This may be considered related to 8b3e2795d3b2d40d67eacc2bfa02c30718eda04c.