### PR TITLE
Fix linter path

### DIFF
--- a/scripts/ci/lint_pull_request.sh
+++ b/scripts/ci/lint_pull_request.sh
@@ -12,7 +12,9 @@ CHANGED_FILES=$(git diff --name-only --diff-filter=AM master..$CURRENT_BRANCH |
 
 if [[ -n "$CHANGED_FILES" ]]; then
   set -x
-  java -jar ../closure-compiler/build/linter.jar $CHANGED_FILES
+  java -jar \
+      ../closure-compiler/target/closure-compiler-linter-1.0-SNAPSHOT.jar \
+      $CHANGED_FILES
 else
   echo "No .js files found to lint in this Pull Request."
 fi


### PR DESCRIPTION
Since the closure compiler moved from ant to maven the path to the linter has to be changed too.

This may be considered related to 8b3e2795d3b2d40d67eacc2bfa02c30718eda04c.