### PR TITLE
Update deprecated KeyEvent keyIdentifier call

### DIFF
--- a/closure/goog/events/keyhandler.js
+++ b/closure/goog/events/keyhandler.js
@@ -429,11 +429,11 @@ goog.events.KeyHandler.prototype.handleEvent = function(e) {
       }
     }
   } else if (
-      be.keyIdentifier &&
-      be.keyIdentifier in goog.events.KeyHandler.keyIdentifier_) {
+      be.key &&
+      be.key in goog.events.KeyHandler.keyIdentifier_) {
     // This is needed for Safari Windows because it currently doesn't give a
     // keyCode/which for non printable keys.
-    key = goog.events.KeyHandler.keyIdentifier_[be.keyIdentifier];
+    key = goog.events.KeyHandler.keyIdentifier_[be.key];
   }
 
   // If we get the same keycode as a keydown/keypress without having seen a


### PR DESCRIPTION
https://www.chromestatus.com/features/5316065118650368 keyIdentifier will no longer be supported as of Chrome 54.