### PR TITLE
Export _displayStringForValue for mockmatchers

### DIFF
--- a/closure/goog/testing/asserts.js
+++ b/closure/goog/testing/asserts.js
@@ -1338,3 +1338,4 @@ goog.exportSymbol('assertRoughlyEquals', assertRoughlyEquals);
 goog.exportSymbol('assertContains', assertContains);
 goog.exportSymbol('assertNotContains', assertNotContains);
 goog.exportSymbol('assertRegExp', assertRegExp);
+goog.exportSymbol('_displayStringForValue', _displayStringForValue);


### PR DESCRIPTION
[goog.testing.mockmatters](https://github.com/google/closure- library/blob/master/closure/goog/testing/mockmatchers.js) relies on _displayStringForValue from goog.testing.asserts. However, that function is not exported from goog.testing.asserts and breaks UMD.

I'm not sure if there is a better approach here, since _displayStringForValue seems to indicate a private function
