### PR TITLE
Teach travis how to regenerate gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,12 @@ script:
   - ./scripts/ci/check_code_format.sh
   - travis_wait 30 ./scripts/ci/run_all_tests.sh
 
+after_success:
+  - ./scripts/ci/generate_latest_docs.sh
+
 env:
   global:
     - SAUCE_USERNAME=closure-sauce
     - SAUCE_ACCESS_KEY=dfd98f70a612-e69a-ad34-6149-3ca056f8
+    - secure: "b8289sSnG5fwT2FPWEFIm1eLsfnjrIdGu0XRiTCR8bFAERZXWY2FdLdhGexhWoYc7R7euahaXoZ/UYc/fG1j6gggpYxEjbyfb/ib/25AK4UEbPFGG8M25xO9nERJ01BzeIaVy08U4CTVsoTR84m5yc1IhlEIRWeH1CfizsDW4U0="
+

--- a/scripts/ci/dossier_readme.md
+++ b/scripts/ci/dossier_readme.md
@@ -1,0 +1,12 @@
+# Closure Generated API Docs
+
+This is the generated documentation for the Closure Library
+repository at
+[github.com/google/closure-library](http://github.com/google/closure-library).
+
+Use the "Search" bar above to find the Closure API you're looking for. For
+example, `goog.array`. Alternatively, explore the APIs using the drop-down
+menu in the top-left corner.
+
+The documentation was produced using
+[github.com/jleyba/js-dossier](http://github.com/jleyba/js-dossier)

--- a/scripts/ci/generate_latest_docs.sh
+++ b/scripts/ci/generate_latest_docs.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Rebuild gh-pages branch, adapted from
+# https://github.com/google/dagger/blob/master/util/generate-latest-docs.sh
+
+DIR=$(mktemp -d)
+mkdir -p "$DIR"
+
+if [ "$TRAVIS_REPO_SLUG" = "google/closure-library" -a \
+     "$TRAVIS_PULL_REQUEST" = "false" -a \
+     "$TRAVIS_BRANCH" = "master" ]; then
+  echo -e "Publishing documentation...\n"
+
+  # Files to omit from documentation
+  declare -A BLACKLIST
+  BLACKLIST['events/eventtargettester.js']=true
+  BLACKLIST['i18n/compactnumberformatsymbolsext.js']=true
+  BLACKLIST['i18n/datetimepatternsext.js']=true
+  BLACKLIST['i18n/numberformatsymbolsext.js']=true
+  BLACKLIST['i18n/listsymbolsext.js']=true
+  BLACKLIST['promise/testsuiteadapter.js']=true
+  BLACKLIST['proto2/package_test.pb.js']=true
+  BLACKLIST['proto2/test.pb.js']=true
+  BLACKLIST['soy/soy_testhelper.js']=true
+  BLACKLIST['style/stylescrollbartester.js']=true
+  BLACKLIST['testing/parallel_closure_test_suite.js']=true
+  BLACKLIST['test_module.js']=true
+  BLACKLIST['test_module_dep.js']=true
+  BLACKLIST['tweak/testhelpers.js']=true
+  BLACKLIST['useragent/useragenttestutil.js']=true
+
+  (
+    # Wipe out any existing documentation entirely.
+    cd "$DIR"
+    git clone --quiet --branch=gh-pages \
+        "https://${GH_TOKEN}@github.com/google/closure-library gh-pages" > /dev/null
+    git config --global user.email "travis@travis-ci.org"
+    git config --global user.name "travis-ci"
+    cd gh-pages
+    find . -path ./.git -prune -o -exec rm -rf {} \; 2> /dev/null || true
+  )
+
+  # Rearrange files from the repo.
+  cp -r doc/* "$DIR/gh-pages/"
+  mkdir -p "$DIR/gh-pages/source/closure"
+  cp -r closure/* "$DIR/gh-pages/source/closure/"
+  mkdir -p "$DIR/gh-pages/api"
+
+  # Download the latest js-dossier release.
+  npm install js-dossier
+
+  # Build up the dossier command line.
+  command=(
+    java -jar node_modules/js-dossier/dossier.jar
+    --output "$DIR/gh-pages/api"
+    --readme scripts/ci/dossier_readme.md
+    --source_url_template
+        'https://github.com/google/closure-library/blob/master/%path%#L%line%'
+    --type_filter '^goog\.i18n\.\w+_.*'
+    --type_filter '^goog\.labs\.i18n\.\w+_.*'
+    --type_filter '^.*+_$'
+  )
+
+  while read -r file; do
+    file=${file#./}
+    if [[ "$file" =~ ^closure/goog/demos ]]; then continue; fi
+    if [[ "$file" =~ _test\.js$ || "$file" =~ _perf\.js$ ]]; then continue; fi
+    if [[ "${BLACKLIST[${file#closure/goog/}]}" == true ]]; then continue; fi
+    if [[ "$file" =~ ^closure/goog || "$file" =~ ^third_party/closure/goog ]]; then
+      command=("${command[@]}" --source "$file")
+    fi
+  done < <(find . -name '*.js')
+
+  # Run dossier.
+  "${command[@]}"
+
+  # Make a commit and push it.
+  (
+    cd "$DIR/gh-pages"
+    git add -A
+    git commit -m "Latest documentation auto-pushed to gh-pages
+
+Built from commit $TRAVIS_COMMIT after successful travis build $TRAVIS_BUILD_NUMBER"
+    git push -fq origin gh-pages > /dev/null
+  )
+
+  echo -e "Published gh-pages.\n";
+fi


### PR DESCRIPTION
Adds a secure token and a script to generate gh-pages.  I've run the script manually (passing in what I believe Travis will pass for the various environment variables) and confirmed that it works.  Next step is to push to master and see if that side is correct.