### PR TITLE
Keep trying to fix generate_latest_docs.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,17 @@
 language: node_js
 sudo: required
 
+# This is required for Java 8 in non-java image
+dist: trusty
+
 cache:
   directories:
     - node_modules
 
 install:
+  # We need jdk8 for JsDossier; but this needs to come first because
+  # otherwise there is no java at all.
+  - jdk_switcher use oraclejdk8
   - ./scripts/ci/install_closure_deps.sh
 
 before_script:
@@ -21,16 +27,28 @@ before_script:
   # clang-format-diff.py invokes "clang-format" with no option of specifying
   # a binary path.
   - export PATH=$PWD/../clang/bin/:$PATH
+  # Make a directory for gh-pages; will be used by both generate_latest_docs.sh
+  # and deploy_latest_docs.sh.
+  - export GH_PAGES=$(mktemp -d)
 
 script:
+  - ./scripts/ci/generate_latest_docs.sh
   - ./scripts/ci/compile_closure.sh
   - ./scripts/ci/lint_pull_request.sh
   - ./scripts/ci/check_code_format.sh
   - travis_wait 30 ./scripts/ci/run_all_tests.sh
-  - ./scripts/ci/generate_latest_docs.sh
+
+after_success:
+  - ./scripts/ci/push_latest_docs.sh
 
 env:
   global:
     - SAUCE_USERNAME=closure-sauce
     - SAUCE_ACCESS_KEY=dfd98f70a612-e69a-ad34-6149-3ca056f8
     - secure: "aEv7CF6ZvD2Fa67yv6yYtgFGjafCkpSP2Y+Dk2AyJCFLF3+L5ZFXpFoCtgYgCWezVDbeGpoojFeCzLu0ycWwnIwJpUQ/C8NBDR/x2Lqz2I6M2PfkEy91UhSE5nXe1RJMnna1715zeBmustiFKjdETWFZrpvxkHixBHbLfY3cJZw="
+
+addons:
+  apt:
+    packages:
+      # Required for jdk_switcher use oraclejdk8
+      - oracle-java8-installer

--- a/scripts/ci/generate_latest_docs.sh
+++ b/scripts/ci/generate_latest_docs.sh
@@ -1,122 +1,89 @@
 #!/bin/bash
 
-# Rebuild gh-pages branch, adapted from
-# https://github.com/google/dagger/blob/master/util/generate-latest-docs.sh
-# See also http://stackoverflow.com/a/22977235 for ssh-based deploy.
+# Rebuild gh-pages branch.
 
-if [ "$TRAVIS_REPO_SLUG" != "google/closure-library" -o \
-     "$TRAVIS_PULL_REQUEST" != "false" -o \
-     "$TRAVIS_BRANCH" != "master" ]; then
-  exit 0
-fi
+set -e
 
-echo "Publishing documentation..."
+echo "Preparing to generate documentation..."
 
-DIR=$(mktemp -d)
-mkdir -p "$DIR"
+COMMIT=${TRAVIS_COMMIT-$(git rev-parse HEAD)}
 
-# Do everything in a subshell so that we can cleanup afterwards.
-(
-  set -e
+export GIT_WORK_TREE="$GH_PAGES"
+export GIT_DIR="$GH_PAGES/.git"
+mkdir -p "$GIT_DIR"
 
-  # Files to omit from documentation
-  BLACKLIST_FILES=(
-    events/eventtargettester.js
-    i18n/compactnumberformatsymbolsext.js
-    i18n/datetimepatternsext.js
-    i18n/listsymbolsext.js
-    i18n/numberformatsymbolsext.js
-    promise/testsuiteadapter.js
-    proto2/package_test.pb.js
-    proto2/test.pb.js
-    soy/soy_testhelper.js
-    style/stylescrollbartester.js
-    testing/parallel_closure_test_suite.js
-    test_module.js
-    test_module_dep.js
-    tweak/testhelpers.js
-    useragent/useragenttestutil.js
-  )
-  declare -A BLACKLIST
-  for file in "${BLACKLIST_FILES[@]}"; do
-     BLACKLIST["$file"]=true
-  done
-
-  # Start by decrypting the deploy password, and pre-populate GitHub's
-  # RSA key to avoid needing to manually accept it when connecting.
-  touch ./scripts/ci/deploy
-  chmod 600 ./scripts/ci/deploy
-  openssl aes-256-cbc -k "$deploy_password" -d -a \
-          -in ./scripts/ci/deploy.enc -out ./scripts/ci/deploy \
-          &> /dev/null
-  echo -e "Host github.com\n  IdentityFile $PWD/scripts/ci/deploy" > ~/.ssh/config
-  echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6Tb
-        Qa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsd
-        lLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+S
-        e8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOz
-        QgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA
-        8VJiS5ap43JXiUFFAaQ==" | sed 's/^ *//' | tr -d '\n' > ~/.ssh/known_hosts
-
-  (
-    # Wipe out any existing documentation entirely.
-    cd "$DIR"
-    git init
-    git remote add origin git@github.com:google/closure-library.git
-    git pull origin gh-pages > /dev/null
-    git config user.email "travis@travis-ci.org"
-    git config user.name "travis-ci"
-    find . -path ./.git -prune -o -exec rm -rf {} \; 2> /dev/null || true
-  )
-
-  # Rearrange files from the repo.
-  cp -r doc/* "$DIR/"
-  mkdir -p "$DIR/source/closure"
-  cp -r closure/* "$DIR/source/closure/"
-  mkdir -p "$DIR/api"
-
-  # Download the latest js-dossier release.
-  npm install js-dossier
-
-  # Build up the dossier command line.
-  command=(
-    java -jar node_modules/js-dossier/dossier.jar
-    --output "$DIR/api"
-    --readme scripts/ci/dossier_readme.md
-    --source_url_template
-        'https://github.com/google/closure-library/blob/master/%path%#L%line%'
-    --type_filter '^goog\.i18n\.\w+_.*'
-    --type_filter '^goog\.labs\.i18n\.\w+_.*'
-    --type_filter '^.*+_$'
-  )
-
-  while read -r file; do
-    file=${file#./}
-    if [[ "$file" =~ ^closure/goog/demos ]]; then continue; fi
-    if [[ "$file" =~ _test\.js$ || "$file" =~ _perf\.js$ ]]; then continue; fi
-    if [[ "${BLACKLIST[${file#closure/goog/}]}" == true ]]; then continue; fi
-    if [[ "$file" =~ ^closure/goog || "$file" =~ ^third_party/closure/goog ]]; then
-      command=("${command[@]}" --source "$file")
-    fi
-  done < <(find . -name '*.js')
-
-  # Run dossier.
-  "${command[@]}"
-
-  (
-    # Make a commit and push it.
-    cd "$DIR"
-    git add -A
-    git commit -m "Latest documentation auto-pushed to gh-pages
-
-Built from commit $TRAVIS_COMMIT after successful travis build $TRAVIS_BUILD_NUMBER"
-    git push -fq origin gh-pages > /dev/null
-  )
-
-  echo -e "Published gh-pages.\n";
+# Files to omit from documentation
+BLACKLIST_FILES=(
+  events/eventtargettester.js
+  i18n/compactnumberformatsymbolsext.js
+  i18n/datetimepatternsext.js
+  i18n/listsymbolsext.js
+  i18n/numberformatsymbolsext.js
+  promise/testsuiteadapter.js
+  proto2/package_test.pb.js
+  proto2/test.pb.js
+  soy/soy_testhelper.js
+  style/stylescrollbartester.js
+  testing/parallel_closure_test_suite.js
+  test_module.js
+  test_module_dep.js
+  tweak/testhelpers.js
+  useragent/useragenttestutil.js
 )
-CODE=$?
+declare -A BLACKLIST
+for file in "${BLACKLIST_FILES[@]}"; do
+   BLACKLIST["$file"]=true
+done
 
-# Clean up by deleting the repository and the decrypted key
-rm -rf "$DIR"
-rm -f ./scripts/ci/deploy
-exit "$CODE"
+# Pull the existing gh-pages branch, but wipe out the workdir
+git init
+git remote add origin https://github.com/google/closure-library.git
+git remote set-url --push origin git@github.com:google/closure-library.git
+git pull --depth=10 origin gh-pages > /dev/null
+git checkout gh-pages
+git config user.email "travis@travis-ci.org"
+git config user.name "travis-ci"
+find "$GH_PAGES" -mindepth 1 -maxdepth 1 -path "$GH_PAGES/.git" -prune -o \
+     -exec rm -rf {} \;
+
+# Rearrange files from the repo.
+cp -r doc/* "$GH_PAGES/"
+mkdir -p "$GH_PAGES/source/closure"
+cp -r closure/* "$GH_PAGES/source/closure/"
+mkdir -p "$GH_PAGES/api"
+
+# Download the latest js-dossier release.
+npm install js-dossier
+
+command=(
+  java -jar node_modules/js-dossier/dossier.jar
+  --output "$GH_PAGES/api"
+  --readme scripts/ci/dossier_readme.md
+  --source_url_template
+      'https://github.com/google/closure-library/blob/master/%path%#L%line%'
+  --type_filter '^goog\.i18n\.\w+_.*'
+  --type_filter '^goog\.labs\.i18n\.\w+_.*'
+  --type_filter '^.*+_$'
+)
+
+# Explicitly add all the non-blacklisted files.
+while read -r file; do
+  if [[ ! "$file" =~ ^closure/goog/demos &&
+        ! "$file" =~ _test\.js$ &&
+        ! "$file" =~ _perf\.js$ &&
+        "${BLACKLIST[${file#closure/goog/}]}" != true ]]; then
+    command=("${command[@]}" --source "$file")
+  fi
+done < <(find closure/goog third_party/closure/goog -name '*.js')
+
+# Run dossier.
+"${command[@]}"
+BUILD=${TRAVIS_BUILD_NUMBER+ after successful travis build $TRAVIS_BUILD_NUMBER}
+
+# Make a commit.
+git add -A
+git commit -m "Latest documentation auto-pushed to gh-pages
+
+Built from commit $COMMIT$BUILD."
+
+echo "gh-pages is ready to push in $GH_PAGES."

--- a/scripts/ci/push_latest_docs.sh
+++ b/scripts/ci/push_latest_docs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Deploy the gh-pages branch, adapted from
+# https://github.com/google/dagger/blob/master/util/generate-latest-docs.sh
+# See also http://stackoverflow.com/a/22977235 for ssh-based deploy.
+
+set -e
+
+# Only push if we've just committed to google/closure-library:master.
+# Start by decrypting the deploy password, and pre-populate GitHub's
+# RSA key to avoid needing to manually accept it when connecting.
+if [ "$TRAVIS_REPO_SLUG" == "google/closure-library" -a \
+     "$TRAVIS_PULL_REQUEST" == "false" -a \
+     "$TRAVIS_BRANCH" == "master" ]; then 
+
+  # If we're on travis, use a secure $deploy_password
+  if [ -n "$deploy_password" ]; then
+    touch scripts/ci/deploy
+    chmod 600 scripts/ci/deploy
+    openssl aes-256-cbc -k "$deploy_password" -d -a \
+            -in scripts/ci/deploy.enc -out scripts/ci/deploy \
+            &> /dev/null
+    echo -e "Host github.com\n  IdentityFile $PWD/scripts/ci/deploy" > ~/.ssh/config
+    echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6Tb
+          Qa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsd
+          lLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+S
+          e8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOz
+          QgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA
+          8VJiS5ap43JXiUFFAaQ==" | sed 's/^ *//' | tr -d '\n' > ~/.ssh/known_hosts
+  fi
+
+  # Push the commit and delete the repo.
+  git push -fq origin gh-pages > /dev/null
+  rm -f scripts/ci/deploy
+  rm -rf "$GH_PAGES"
+  echo "Published gh-pages."
+
+fi


### PR DESCRIPTION
In particular, this fixes the current error (wrong java version on travis - needs to be Java8) and also fixes a few other problems with the script.  It now runs on all presubmit checks, but only prepares the commit, rather than actually deploying it, for presubmits.