### PR TITLE
Set unusedLocals as warning, for now

### DIFF
--- a/scripts/ci/compile_closure.sh
+++ b/scripts/ci/compile_closure.sh
@@ -15,6 +15,7 @@ java -Xmx1G -jar ../closure-compiler/target/closure-compiler-1.0-SNAPSHOT.jar \
   --jscomp_off=deprecated \
   --jscomp_off=lintChecks \
   --jscomp_off=analyzerChecks \
+  --jscomp_warning=unusedLocal \
   --js='**.js' \
   --js='!**_test.js' \
   --js='!**_perf.js' \


### PR DESCRIPTION
Recent compiler release introduced a bunch of new unused local failures