### PR TITLE
Fix parsing empty cookies in IE/Edge

### DIFF
--- a/closure/goog/net/cookies.js
+++ b/closure/goog/net/cookies.js
@@ -189,7 +189,8 @@ goog.net.Cookies.prototype.set = function(
 goog.net.Cookies.prototype.get = function(name, opt_default) {
   var nameEq = name + '=';
   var parts = this.getParts_();
-  for (var i = 0, part; part = parts[i]; i++) {
+  for (var i = 0, part; i < parts.length; i++) {
+    part = parts[i];
     // startsWith
     if (part.lastIndexOf(nameEq, 0) == 0) {
       return part.substr(nameEq.length);
@@ -341,7 +342,8 @@ goog.net.Cookies.prototype.getParts_ = function() {
 goog.net.Cookies.prototype.getKeyValues_ = function() {
   var parts = this.getParts_();
   var keys = [], values = [], index, part;
-  for (var i = 0; part = parts[i]; i++) {
+  for (var i = 0; i < parts.length; i++) {
+    part = parts[i];
     index = part.indexOf('=');
 
     if (index == -1) {  // empty name

--- a/closure/goog/net/cookies_test.js
+++ b/closure/goog/net/cookies_test.js
@@ -209,6 +209,16 @@ function testGetEmptyCookieIE() {
   assertEquals('', cookies.get('test3'));
 }
 
+function testGetReallyEmptyCookieIE() {
+  stubs.set(
+      cookies, 'getCookie_', function() { return 'test1; ; test3'; });
+
+  assertEquals('', cookies.get('test1'));
+  assertEquals('', cookies.get(''));
+  assertEquals('', cookies.get('test3'));
+  assertEquals(3, cookies.getCount());
+}
+
 // TODO(chrisn): Testing max age > 0 requires a mock clock.
 
 function mockSetCookie(var_args) {


### PR DESCRIPTION
IE/Edge accepts an empty Set-Cookie header and adds an empty part to document.cookie

I don't care how this aberrant cookie is parsed, but currently the parsing stops when it encounters this empty cookie.