### PR TITLE
Accommodate parsing of java version strings >= JDK 9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Filipe Catraia <filipe.catraia@deliveryhero.com>
 Dan Rubalsky <drubalsky@plentakill.com>
 Michael Zhou <zhoumotongxue008@gmail.com>
 mash <mashedcode@users.noreply.github.com>
+Cody Raspen <cody+github@raspen.org>

--- a/closure/bin/build/jscompiler.py
+++ b/closure/bin/build/jscompiler.py
@@ -20,9 +20,9 @@ import subprocess
 import tempfile
 
 # Pulls just the major and minor version numbers from the first line of
-# 'java -version'. Versions are in the format of [0-9]+\.[0-9]+\..* See:
-# http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
-_VERSION_REGEX = re.compile(r'"([0-9]+)\.([0-9]+)')
+# 'java -version'. Versions are in the format of [0-9]+(\.[0-9]+)? See:
+# http://openjdk.java.net/jeps/223
+_VERSION_REGEX = re.compile(r'"([0-9]+)(?:\.([0-9]+))?')
 
 
 class JsCompilerError(Exception):
@@ -46,7 +46,7 @@ def _ParseJavaVersion(version_string):
   """
   match = _VERSION_REGEX.search(version_string)
   if match:
-    version = tuple(int(x, 10) for x in match.groups())
+    version = tuple(int(x or 0) for x in match.groups())
     assert len(version) == 2
     return version
 

--- a/closure/bin/build/jscompiler_test.py
+++ b/closure/bin/build/jscompiler_test.py
@@ -92,6 +92,7 @@ class JsCompilerTestCase(unittest.TestCase):
     def assertVersion(expected, version_string):
       self.assertEquals(expected, jscompiler._ParseJavaVersion(version_string))
 
+    assertVersion((9, 0), _TEST_JAVA_JEP_223_VERSION_STRING)
     assertVersion((1, 7), _TEST_JAVA_VERSION_STRING)
     assertVersion((1, 6), _TEST_JAVA_NESTED_VERSION_STRING)
     assertVersion((1, 4), 'java version "1.4.0_03-ea"')
@@ -108,6 +109,12 @@ Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
 java version "1.6.0_35"
 Java(TM) SE Runtime Environment (build 1.6.0_35-b10-428-11M3811)
 Java HotSpot(TM) Client VM (build 20.10-b01-428, mixed mode)
+"""
+
+_TEST_JAVA_JEP_223_VERSION_STRING = """\
+openjdk version "9-Ubuntu"
+OpenJDK Runtime Environment (build 9-Ubuntu+0-9b134-2ubuntu1)
+OpenJDK 64-Bit Server VM (build 9-Ubuntu+0-9b134-2ubuntu1, mixed mode)
 """
 
 if __name__ == '__main__':


### PR DESCRIPTION
[JEP 223](http://openjdk.java.net/jeps/223) brings about a new java version string scheme.

Fixes #794 