### PR TITLE
Remove Sha1 from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ require("google-closure-library");
 
 goog.require("goog.crypt.Sha1");
 
-var sha1 = new goog.crypt.Sha1();
-sha1.update("foobar");
-var hash = sha1.digest();
+var sha1 = new goog.crypt.Sha2();
+sha2.update("foobar");
+var hash = sha2.digest();
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Require the package and use goog.require normally.
 ```
 require("google-closure-library");
 
-goog.require("goog.crypt.Sha1");
+goog.require("goog.crypt.Sha2");
 
 var sha1 = new goog.crypt.Sha2();
 sha2.update("foobar");


### PR DESCRIPTION
Here it is harmless, but it could go far. Since SHA-2 is in the closure library, the README should default to using SHA-2 to prevent instilling bad habits that could have consequences.