### PR TITLE
Fix push_latest_docs to export GIT_DIR correctly

### DIFF
--- a/scripts/ci/push_latest_docs.sh
+++ b/scripts/ci/push_latest_docs.sh
@@ -30,6 +30,8 @@ if [ "$TRAVIS_REPO_SLUG" == "google/closure-library" -a \
   fi
 
   # Push the commit and delete the repo.
+  export GIT_WORK_TREE="$GH_PAGES"
+  export GIT_DIR="$GH_PAGES/.git"
   git push -fq origin gh-pages > /dev/null
   rm -f scripts/ci/deploy
   rm -rf "$GH_PAGES"


### PR DESCRIPTION
Previously we were getting errors about "src refspec gh-pages does not match any." because we were trying to push from the wrong repo.

RELNOTES=n/a