### PR TITLE
Fix return type of IndexedDB.prototype.version

### DIFF
--- a/closure/goog/db/indexeddb.js
+++ b/closure/goog/db/indexeddb.js
@@ -138,10 +138,11 @@ goog.db.IndexedDb.prototype.getName = function() {
 
 
 /**
- * @return {string} The current database version.
+ * @return {number} The current database version.
  */
 goog.db.IndexedDb.prototype.getVersion = function() {
-  return this.db_.version;
+  // TODO: drop Number() call once closure compiler's externs are updated
+  return Number(this.db_.version);
 };
 
 


### PR DESCRIPTION
Current browsers return a number. This was specced in [W3C Working Draft 06 December 2011](https://www.w3.org/TR/2011/WD-IndexedDB-20111206/#idl-def-IDBDatabase).
I don't know about any browser which return a string here.

This PR is prerequisite for google/closure-compiler#2035.

See
https://www.w3.org/TR/IndexedDB/#idl-def-IDBDatabase
https://github.com/google/closure-compiler/pull/2035#issuecomment-286847194

/cc @brad4d 