### PR TITLE
Fix IDBIndex.keyPath type

### DIFF
--- a/closure/goog/db/index.js
+++ b/closure/goog/db/index.js
@@ -58,7 +58,7 @@ goog.db.Index.prototype.getName = function() {
 
 
 /**
- * @return {string} Key path of the index.
+ * @return {*} Key path of the index.
  */
 goog.db.Index.prototype.getKeyPath = function() {
   return this.index_.keyPath;


### PR DESCRIPTION
This may return any type which was specced in [W3C Last Call Working Draft 16 May 2013](https://www.w3.org/TR/2013/WD-IndexedDB-20130516/#idl-def-IDBIndex).

This PR is prerequisite for google/closure-compiler#2035.

See
https://www.w3.org/TR/IndexedDB/#idl-def-IDBIndex
https://github.com/google/closure-compiler/pull/2035#issuecomment-286847194