### PR TITLE
Resolved issue #755[closure calls its own deprecated installStyles method] and loremipsum.js setHtml() changed to setSafeHtml() 

### DIFF
--- a/closure/goog/editor/field.js
+++ b/closure/goog/editor/field.js
@@ -2295,7 +2295,9 @@ goog.editor.Field.prototype.turnOnDesignModeGecko = function() {
  */
 goog.editor.Field.prototype.installStyles = function() {
   if (this.cssStyles && this.shouldLoadAsynchronously()) {
-    goog.style.installStyles(this.cssStyles, this.getElement());
+    goog.style.installSafeStyleSheet(
+        goog.html.legacyconversions.safeStyleSheetFromString(this.cssStyles),
+        this.getElement());
   }
 };
 

--- a/closure/goog/editor/plugins/loremipsum.js
+++ b/closure/goog/editor/plugins/loremipsum.js
@@ -29,6 +29,7 @@ goog.require('goog.editor.Field');
 goog.require('goog.editor.Plugin');
 goog.require('goog.editor.node');
 goog.require('goog.functions');
+goog.require('goog.html.SafeHtml');
 goog.require('goog.userAgent');
 
 
@@ -139,7 +140,9 @@ goog.editor.plugins.LoremIpsum.prototype.updateLorem_ = function() {
       // clear the lorem ipsum style.
       this.oldFontStyle_ = field.style.fontStyle;
       field.style.fontStyle = 'italic';
-      fieldObj.setHtml(true, this.message_, true);
+      fieldObj.setSafeHtml(
+          true, goog.html.SafeHtml.htmlEscapePreservingNewlines(this.message_),
+          true);
     }
   }
 };
@@ -173,7 +176,7 @@ goog.editor.plugins.LoremIpsum.prototype.clearLorem_ = function(
     goog.asserts.assert(field);
     this.usingLorem_ = false;
     field.style.fontStyle = this.oldFontStyle_;
-    fieldObj.setHtml(true, null, true);
+    fieldObj.setSafeHtml(true, null, true);
 
     // TODO(nicksantos): I'm pretty sure that this is a hack, but talk to
     // Julie about why this is necessary and what to do with it. Really,

--- a/closure/goog/editor/seamlessfield.js
+++ b/closure/goog/editor/seamlessfield.js
@@ -39,6 +39,7 @@ goog.require('goog.editor.icontent.FieldStyleInfo');
 goog.require('goog.editor.node');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.html.legacyconversions');
 goog.require('goog.html.uncheckedconversions');
 goog.require('goog.log');
 goog.require('goog.string.Const');
@@ -430,7 +431,8 @@ goog.editor.SeamlessField.prototype.inheritBlendedCSS = function() {
   // we're applying the 'blend' for the first time, or because we
   // *need* to recompute the blend.
   var newCSS = this.getIframeableCss(true);
-  goog.style.installStyles(newCSS, field);
+  goog.style.installSafeStyleSheet(
+      goog.html.legacyconversions.safeStyleSheetFromString(newCSS), field);
 };
 
 
@@ -558,7 +560,10 @@ goog.editor.SeamlessField.prototype.installStyles = function() {
   if (!this.usesIframe()) {
     if (!goog.editor.SeamlessField.haveInstalledCss_) {
       if (this.cssStyles) {
-        goog.style.installStyles(this.cssStyles, this.getElement());
+        goog.style.installSafeStyleSheet(
+            goog.html.legacyconversions.safeStyleSheetFromString(
+                this.cssStyles),
+            this.getElement());
       }
 
       // TODO(user): this should be reset to false when the editor is quit.


### PR DESCRIPTION
Trying to allow plovr 6.0.0 to compile my code which use goog.editor.field, seamlessfield, etc.

 ```
    [java] /closure/goog/editor/field.js:2298: ERROR - Property installStyles of type goog.style has been deprecated: Use {@link #installSafeStyleSheet} instead.
     [java]     goog.style.installStyles(this.cssStyles, this.getElement());
     [java]     ^
     [java] 
     [java] /closure/goog/editor/plugins/loremipsum.js:142: ERROR - Property setHtml of type goog.editor.Field has been deprecated: Use setSafeHtml instead.
     [java]       fieldObj.setHtml(true, this.message_, true);
     [java]       ^
     [java] 
     [java] /closure/goog/editor/plugins/loremipsum.js:176: ERROR - Property setHtml of type goog.editor.Field has been deprecated: Use setSafeHtml instead.
     [java]     fieldObj.setHtml(true, null, true);
     [java]     ^
     [java] 
     [java] /closure/goog/editor/seamlessfield.js:433: ERROR - Property installStyles of type goog.style has been deprecated: Use {@link #installSafeStyleSheet} instead.
     [java]   goog.style.installStyles(newCSS, field);
     [java]   ^
     [java] 
     [java] /closure/goog/editor/seamlessfield.js:561: ERROR - Property installStyles of type goog.style has been deprecated: Use {@link #installSafeStyleSheet} instead.
     [java]         goog.style.installStyles(this.cssStyles, this.getElement());
     [java]         ^
     [java] 
     [java] 5 error(s), 0 warning(s), 95.7% typed
```