### PR TITLE
Strict definition for IDBDatabase.createObjectStore method

### DIFF
--- a/closure/goog/db/indexeddb.js
+++ b/closure/goog/db/indexeddb.js
@@ -160,7 +160,8 @@ goog.db.IndexedDb.prototype.getObjectStoreNames = function() {
  * {@link goog.db.UpgradeNeededCallback}.
  *
  * @param {string} name Name for the new object store.
- * @param {Object=} opt_params Options object. The available options are:
+ * @param {!IDBObjectStoreParameters=} opt_params Options object.
+ *     The available options are:
  *     keyPath, which is a string and determines what object attribute
  *     to use as the key when storing objects in this object store; and
  *     autoIncrement, which is a boolean, which defaults to false and determines


### PR DESCRIPTION
This PR is prerequisite for google/closure-compiler#2035.

See
https://www.w3.org/TR/IndexedDB/#idl-def-IDBDatabase
https://github.com/google/closure-compiler/pull/2035#issuecomment-286847194

/cc @brad4d 