### PR TITLE
Remove deprecation of method without alternative that's still in use in project

### DIFF
--- a/closure/goog/testing/testcase.js
+++ b/closure/goog/testing/testcase.js
@@ -710,7 +710,6 @@ goog.testing.TestCase.prototype.getNumFilesLoaded = function() {
  * Returns the test results object: a map from test names to a list of test
  * failures (if any exist).
  * @return {!Object<string, !Array<string>>} Tests results object.
- * @deprecated
  */
 // TODO(dankurka): Delete this once testing infrastructure has been updated
 // and released


### PR DESCRIPTION
Namely: https://github.com/google/closure-library/blob/0592a220b21b53db3cb77caaaea69cadec20789d/closure/goog/testing/testrunner.js#L440 is using this.

https://github.com/google/closure-library/issues/821