### PR TITLE
Fix html sanitizer bug

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Filipe Catraia <filipe.catraia@deliveryhero.com>
 Dan Rubalsky <drubalsky@plentakill.com>
 Michael Zhou <zhoumotongxue008@gmail.com>
 mash <mashedcode@users.noreply.github.com>
+Ryan <github@kwivix.net>

--- a/closure/goog/html/sanitizer/htmlsanitizer.js
+++ b/closure/goog/html/sanitizer/htmlsanitizer.js
@@ -1377,8 +1377,8 @@ goog.html.sanitizer.HtmlSanitizer.prototype.sanitizeAttribute_ = function(
     dirtyNode, attribute) {
   var attributeName = attribute.name;
   if (goog.string.startsWith(
-          goog.html.sanitizer.HTML_SANITIZER_BOOKKEEPING_PREFIX_,
-          attributeName)) {
+          attributeName,
+          goog.html.sanitizer.HTML_SANITIZER_BOOKKEEPING_PREFIX_)) {
     return null;
   }
 

--- a/closure/goog/html/sanitizer/unsafe_test.js
+++ b/closure/goog/html/sanitizer/unsafe_test.js
@@ -170,8 +170,8 @@ function testAllowOverwriteAttrPolicy() {
 function testAllowDAttribute() {
   var input = '<path d="1.5 1.5 1.5 14.5 14.5 14.5 14.5 1.5"/>';
   var expected = '<path d="1.5 1.5 1.5 14.5 14.5 14.5 14.5 1.5"/>';
-  assertSanitizedHtml(input, expected,
-                      ['path'], [{tagName: 'path', attributeName: 'd'}]);
+  assertSanitizedHtml(input, expected, ['path'],
+                      [{tagName: 'path', attributeName: 'd'}]);
 }
 
 

--- a/closure/goog/html/sanitizer/unsafe_test.js
+++ b/closure/goog/html/sanitizer/unsafe_test.js
@@ -170,7 +170,8 @@ function testAllowOverwriteAttrPolicy() {
 function testAllowDAttribute() {
   var input = '<path d="1.5 1.5 1.5 14.5 14.5 14.5 14.5 1.5"/>';
   var expected = '<path d="1.5 1.5 1.5 14.5 14.5 14.5 14.5 1.5"/>';
-  assertSanitizedHtml(input, expected, ['path'], [{tagName: 'path', attributeName: 'd'}]);
+  assertSanitizedHtml(input, expected,
+                      ['path'], [{tagName: 'path', attributeName: 'd'}]);
 }
 
 

--- a/closure/goog/html/sanitizer/unsafe_test.js
+++ b/closure/goog/html/sanitizer/unsafe_test.js
@@ -167,6 +167,13 @@ function testAllowOverwriteAttrPolicy() {
 }
 
 
+function testAllowDAttribute() {
+  var input = '<path d="1.5 1.5 1.5 14.5 14.5 14.5 14.5 1.5"/>';
+  var expected = '<path d="1.5 1.5 1.5 14.5 14.5 14.5 14.5 1.5"/>';
+  assertSanitizedHtml(input, expected, ['path'], [{tagName: 'path', attributeName: 'd'}]);
+}
+
+
 function testWhitelistAliasing() {
   var builder = new goog.html.sanitizer.HtmlSanitizer.Builder();
   goog.html.sanitizer.unsafe.alsoAllowTags(just, builder, ['QqQ']);


### PR DESCRIPTION
The argument order of `startsWith` is wrong. As side effect the d attribute of path is not allowed.