### PR TITLE
goog.crypt.stringToByteArray(): use if instead of while since String.…

### DIFF
--- a/closure/goog/crypt/crypt.js
+++ b/closure/goog/crypt/crypt.js
@@ -33,7 +33,7 @@ goog.crypt.stringToByteArray = function(str) {
   var output = [], p = 0;
   for (var i = 0; i < str.length; i++) {
     var c = str.charCodeAt(i);
-    while (c > 0xff) {
+    if (c > 0xff) {
       output[p++] = c & 0xff;
       c >>= 8;
     }


### PR DESCRIPTION
…prototype.charCodeAt() can only return values up to 0xFFFF
#827 
