### PR TITLE
Fix lint_pull_request.sh to use linter pulled from snapshot.

### DIFF
--- a/scripts/ci/install_closure_deps.sh
+++ b/scripts/ci/install_closure_deps.sh
@@ -7,11 +7,25 @@ declare -r CLANG_VERSION="3.7.1"
 declare -r CLANG_BUILD="clang+llvm-${CLANG_VERSION}-x86_64-linux-gnu-ubuntu-14.04"
 declare -r CLANG_TAR="${CLANG_BUILD}.tar.xz"
 declare -r CLANG_URL="http://llvm.org/releases/${CLANG_VERSION}/${CLANG_TAR}"
-declare -r CLOSURE_COMPILER_REPO="https://oss.sonatype.org/content/repositories/snapshots/com/google/javascript/closure-compiler/1.0-SNAPSHOT/"
 
 set -ex
 
 cd ..
+
+# Fetches Closure Compiler components from oss.sonatype.org
+fetch () {
+  local name="$1"
+  local snapshots="https://oss.sonatype.org/content/repositories/snapshots"
+  local repo="$snapshots/com/google/javascript"
+  local dir="$repo/$name/1.0-SNAPSHOT"
+  local jar="$name-1.0-SNAPSHOT.jar"
+  local url=$(
+    curl -o - "$dir/" |
+      sed -n 's+.*<a href="\('"$dir/$name"'-[-.0-9]*\.jar\)".*+\1+p' |
+      head -n 1)
+  [ -n $url ]
+  wget -O "$jar" "$url"
+}
 
 # Install clang-format.
 wget --quiet $CLANG_URL
@@ -20,12 +34,8 @@ mv $CLANG_BUILD clang
 rm -f $CLANG_TAR
 
 # Install closure compiler and linter.
-CLOSURE_URL=$(
-  curl -o - "$CLOSURE_COMPILER_REPO" |
-    sed -n 's+.*<a href="\('"$CLOSURE_COMPILER_REPO"'closure-compiler-[-.0-9]*\.jar\)".*+\1+p' |
-    head -n 1)
-[ -n $CLOSURE_URL ]
-wget -O closure-compiler-1.0-SNAPSHOT.jar "$CLOSURE_URL"
+fetch closure-compiler
+fetch closure-compiler-linter
 
 cd closure-library
 

--- a/scripts/ci/lint_pull_request.sh
+++ b/scripts/ci/lint_pull_request.sh
@@ -12,9 +12,7 @@ CHANGED_FILES=$(git diff --name-only --diff-filter=AM master..$CURRENT_BRANCH |
 
 if [[ -n "$CHANGED_FILES" ]]; then
   set -x
-  java -jar \
-      ../closure-compiler/target/closure-compiler-linter-1.0-SNAPSHOT.jar \
-      $CHANGED_FILES
+  java -jar ../closure-compiler-linter-1.0-SNAPSHOT.jar $CHANGED_FILES
 else
   echo "No .js files found to lint in this Pull Request."
 fi


### PR DESCRIPTION
Ever since 84b8392 linting PRs has failed, since we no longer download and build the Closure Compiler repo from source.