### PR TITLE
Fixed spelling mistake "readble" --> "readable"

### DIFF
--- a/closure/goog/labs/mock/mock.js
+++ b/closure/goog/labs/mock/mock.js
@@ -145,7 +145,7 @@ goog.labs.mock.getFunctionName_ = function(func) {
 
 
 /**
- * Returns a nicely formatted, readble representation of a method call.
+ * Returns a nicely formatted, readable representation of a method call.
  * @private
  * @param {string} methodName The name of the method.
  * @param {Array<?>=} opt_args The method arguments.


### PR DESCRIPTION
There was one instance where "readable" was spelt as "readble".