### PR TITLE
add goog.date.DateTime.timeEquals function

### DIFF
--- a/closure/goog/date/date.js
+++ b/closure/goog/date/date.js
@@ -1665,6 +1665,18 @@ goog.date.DateTime.prototype.equals = function(other) {
 
 
 /**
+ * Tests whether given time part of datetime is exactly equal to time part of this DateTime.
+ *
+ * @param {goog.date.DateTime} other The datetime to compare.
+ * @return {boolean} Whether the given time part of datetime is exactly equal to time part of this one.
+ * @override
+ */
+goog.date.DateTime.prototype.timeEquals = function(other) {
+  return other && this.getHours() == other.getHours() && this.getMinutes() == other.getMinutes() && this.getSeconds() == other.getSeconds() && this.getMilliseconds() == other.getMilliseconds();
+};
+
+
+/**
  * Overloaded toString method for object.
  * @return {string} ISO 8601 string representation of date/time.
  * @override

--- a/closure/goog/date/date_test.js
+++ b/closure/goog/date/date_test.js
@@ -970,6 +970,41 @@ function testDateTimeEquals() {
   assertTrue('using goog.date.Date, same time (midnight)', d1.equals(d2));
 }
 
+function testTimeEquals() {
+  var t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  var t2 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  assertTrue('t1 == t2', t1.timeEquals(t2));
+  assertTrue('t2 == t1', t2.timeEquals(t1));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2005, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  assertTrue('different year', t1.timeEquals(t2));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2004, goog.date.month.JAN, 1, 12, 30, 30, 500);
+  assertTrue('different month', t1.timeEquals(t2));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2004, goog.date.month.MAR, 2, 12, 30, 30, 500);
+  assertTrue('different date', t1.timeEquals(t2));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 13, 30, 30, 500);
+  assertFalse('different hour', t1.timeEquals(t2));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 40, 30, 500);
+  assertFalse('different minute', t1.timeEquals(t2));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 40, 500);
+  assertFalse('different second', t1.timeEquals(t2));
+
+  t1 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 500);
+  t2 = new goog.date.DateTime(2004, goog.date.month.MAR, 1, 12, 30, 30, 600);
+  assertFalse('different millisecond', t1.timeEquals(t2));
+}
+
 
 function testIntervalIsZero() {
   assertTrue('zero interval', new goog.date.Interval().isZero());


### PR DESCRIPTION
I came to a problem, where I needed to compare two DateTimes, but I was only interested in comparing the time part regardless of the year/mont/date value. Since I did not found any existing function that could do that, I have added a **timeEquals** method to **goog.date.DateTime**.

Do you think such a function might be of a good use for someone else or is it just me needing it? Or is there a better way to check whether two times are equal?

Thanks for any comments and ideas.