### PR TITLE
Add .npmignore and reduce npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+*.html
+*_test.*
+.*
+/*.js
+/*.json
+/closure/bin/generate_closure_unit_tests
+/closure/goog/demos/
+/doc
+/scripts
+testdata


### PR DESCRIPTION
`npm pack`ed tgz is reduced from 4.9MB to 3.1MB.
The diff list is https://gist.github.com/teppeis/743264bf135ef712daaae9872a93d091