### PR TITLE
Update promises_aplus_tests dependency

### DIFF
--- a/closure/goog/promise/testsuiteadapter.js
+++ b/closure/goog/promise/testsuiteadapter.js
@@ -30,7 +30,7 @@ goog.setTestOnly('goog.promise.testSuiteAdapter');
 
 
 var promisesAplusTests = /** @type {function(!Object, function(*))} */ (
-    require('promises_aplus_tests'));
+    require('promises-aplus-tests'));
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "devDependencies": {
     "promise": "^7.0.4",
     "protractor": "^2.1.0"
+  },
+  "dependencies": {
+    "promises-aplus-tests": "^2.1.2"
   }
 }


### PR DESCRIPTION
promises_aplus_tests does not exist anymore.
Now its name is promises-aplus-tests.

This closes #701