### PR TITLE
Fix closurebuilder.py compilerflags on python >= 3.5

### DIFF
--- a/closure/bin/build/jscompiler.py
+++ b/closure/bin/build/jscompiler.py
@@ -118,7 +118,7 @@ def _GetFlagFile(source_paths, compiler_flags):
   if compiler_flags:
     args += compiler_flags
 
-  flags_file = tempfile.NamedTemporaryFile(delete=False)
+  flags_file = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
   flags_file.write(' '.join(args))
   flags_file.close()
 

--- a/closure/bin/build/jscompiler_test.py
+++ b/closure/bin/build/jscompiler_test.py
@@ -91,7 +91,7 @@ class JsCompilerTestCase(unittest.TestCase):
   def testGetJavaVersion(self):
 
     def assertVersion(expected, version_string):
-      self.assertEquals(expected, jscompiler._ParseJavaVersion(version_string))
+      self.assertEqual(expected, jscompiler._ParseJavaVersion(version_string))
 
     assertVersion((9, 0), _TEST_JAVA_JEP_223_VERSION_STRING)
     assertVersion((1, 7), _TEST_JAVA_VERSION_STRING)

--- a/closure/bin/build/source_test.py
+++ b/closure/bin/build/source_test.py
@@ -68,7 +68,7 @@ class SourceTestCase(unittest.TestCase):
     self.assertTrue(test_source.is_goog_module)
 
   def testStripComments(self):
-    self.assertEquals(
+    self.assertEqual(
         '\nvar foo = function() {}',
         source.Source._StripComments((
             '/* This is\n'

--- a/closure/bin/labs/code/generate_jsdoc_test.py
+++ b/closure/bin/labs/code/generate_jsdoc_test.py
@@ -39,20 +39,20 @@ class InsertJsDocTestCase(unittest.TestCase):
     self.assertEqual('', match.group('arguments'))
 
     match = generate_jsdoc._MatchFirstFunction(_ODD_NEWLINES_SOURCE)
-    self.assertEquals('goog.\nfoo.\nbar\n.baz.\nqux',
+    self.assertEqual('goog.\nfoo.\nbar\n.baz.\nqux',
                       match.group('identifier'))
 
   def testParseArgString(self):
-    self.assertEquals(
+    self.assertEqual(
         ['foo', 'bar', 'baz'],
         list(generate_jsdoc._ParseArgString('foo, bar, baz')))
 
   def testExtractFunctionBody(self):
-    self.assertEquals(
+    self.assertEqual(
         '\n  // Function comments.\n  return;\n',
         generate_jsdoc._ExtractFunctionBody(_TEST_SOURCE))
 
-    self.assertEquals(
+    self.assertEqual(
         '\n    var bar = 3;\n    return true;\n',
         generate_jsdoc._ExtractFunctionBody(_INDENTED_SOURCE, 2))
 
@@ -61,20 +61,20 @@ class InsertJsDocTestCase(unittest.TestCase):
     self.assertFalse(generate_jsdoc._ContainsReturnValue(_TEST_SOURCE))
 
   def testInsertString(self):
-    self.assertEquals(
+    self.assertEqual(
         'abc123def',
         generate_jsdoc._InsertString('abcdef', '123', 3))
 
   def testInsertJsDoc(self):
-    self.assertEquals(
+    self.assertEqual(
         _EXPECTED_INDENTED_SOURCE,
         generate_jsdoc.InsertJsDoc(_INDENTED_SOURCE))
 
-    self.assertEquals(
+    self.assertEqual(
         _EXPECTED_TEST_SOURCE,
         generate_jsdoc.InsertJsDoc(_TEST_SOURCE))
 
-    self.assertEquals(
+    self.assertEqual(
         _EXPECTED_ODD_NEWLINES_SOURCE,
         generate_jsdoc.InsertJsDoc(_ODD_NEWLINES_SOURCE))
 


### PR DESCRIPTION
Closes https://github.com/google/closure-library/issues/849

While I created this small fix, I also ran into a deprecation warning in python `assertEquals()` calls when running the tests on python 2.7, 3.4, 3.5, 3.6, so I also fixed those.