### PR TITLE
Fix for issue #876

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@
 # Use of this source code is governed by the Apache License, Version 2.0.
 # See the LICENSE file for details.
 
-# simple change: to for triggering travisci
-# change for travis/sauce 
 
 language: node_js
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 # Use of this source code is governed by the Apache License, Version 2.0.
 # See the LICENSE file for details.
 
+# simple change: to for triggering travisci
+# change for travis/sauce 
+
 language: node_js
 sudo: required
 

--- a/closure/goog/ui/sliderbase.js
+++ b/closure/goog/ui/sliderbase.js
@@ -1114,13 +1114,21 @@ goog.ui.SliderBase.prototype.getThumbCoordinateForValue = function(val) {
       var thumbHeight = this.valueThumb.offsetHeight;
       var h = this.getElement().clientHeight - thumbHeight;
       var bottom = Math.round(ratio * h);
-      coord.x = this.getOffsetStart_(this.valueThumb);  // Keep x the same.
+      if(this.moveToPointEnabled_) {
+        coord.x = '0px';
+      } else {
+        coord.x = this.getOffsetStart_(this.valueThumb);  // Keep x the same.
+      }
       coord.y = h - bottom;
     } else {
       var w = this.getElement().clientWidth - this.valueThumb.offsetWidth;
       var left = Math.round(ratio * w);
       coord.x = left;
-      coord.y = this.valueThumb.offsetTop;  // Keep y the same.
+      if(this.moveToPointEnabled_) {
+        coord.y = '0px';
+      } else {
+        coord.y = this.valueThumb.offsetTop;  // Keep y the same.
+      }
     }
   }
   return coord;


### PR DESCRIPTION
Thumb in goog.ui.Slider widget drifts off when MoveToPointEnabled is true and thumb div is styled with offset properties (margin-top, margin-left);

Please see https://github.com/google/closure-library/issues/876
