### PR TITLE
Fix a type warning for textContent

### DIFF
--- a/closure/goog/dom/dom.js
+++ b/closure/goog/dom/dom.js
@@ -1756,7 +1756,7 @@ goog.dom.setTextContent = function(node, text) {
       'goog.dom.setTextContent expects a non-null value for node');
 
   if ('textContent' in node) {
-    node.textContent = text;
+    node.textContent = '' + text;
   } else if (node.nodeType == goog.dom.NodeType.TEXT) {
     /** @type {!Text} */ (node).data = String(text);
   } else if (


### PR DESCRIPTION
Currently, I see the following warning when compiling Closure Library with ADVANCED mode.
This PR is to fix this, which is casting `number` to `string` by concatenating an empty string.

```
WARNING in ./node_modules/google-closure-library/closure/goog/dom/dom.js:1759 from closure-compiler: The right side in the assignment is not a subtype of the left side.
Expected : string
Found    : (number|string)
More details:
The found type is a union that includes an unexpected type: number
    node.textContent = text;
    ^^^^^^^^^^^^^^^^^^^^^^^
```

Thanks!