### PR TITLE
Fix comment in aria_test.js

### DIFF
--- a/closure/goog/a11y/aria/aria_test.js
+++ b/closure/goog/a11y/aria/aria_test.js
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS-IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.goog.provide('goog.a11y.ariaTest');
+// limitations under the License.
 
 goog.provide('goog.a11y.ariaTest');
 goog.setTestOnly('goog.a11y.ariaTest');


### PR DESCRIPTION
Fix a comment in aria_test.js where `goog.provide` was accidentally added in the license comment.