### PR TITLE
Add support for YouTube /embed/ and -nocookie URLs

### DIFF
--- a/closure/goog/ui/media/youtube.js
+++ b/closure/goog/ui/media/youtube.js
@@ -243,7 +243,8 @@ goog.inherits(goog.ui.media.YoutubeModel, goog.ui.media.MediaModel);
 goog.ui.media.YoutubeModel.MATCHER_ = new RegExp(
     // Lead in.
     'https?://(?:[a-zA-Z]{1,3}\\.)?' +
-        // Watch short URL prefix and /embed/ URLs. This should handle URLs like:
+        // Watch short URL prefix and /embed/ URLs. This should handle URLs
+        // like:
         // https://youtu.be/jqxENMKaeCU?cgiparam=value
         // https://youtube.com/embed/jqxENMKaeCU?cgiparam=value
         // https://youtube-nocookie.com/jqxENMKaeCU?cgiparam=value

--- a/closure/goog/ui/media/youtube.js
+++ b/closure/goog/ui/media/youtube.js
@@ -243,13 +243,16 @@ goog.inherits(goog.ui.media.YoutubeModel, goog.ui.media.MediaModel);
 goog.ui.media.YoutubeModel.MATCHER_ = new RegExp(
     // Lead in.
     'https?://(?:[a-zA-Z]{1,3}\\.)?' +
-        // Watch short URL prefix. This should handle URLs of the form:
+        // Watch short URL prefix and /embed/ URLs. This should handle URLs like:
         // https://youtu.be/jqxENMKaeCU?cgiparam=value
-        '(?:(?:youtu\\.be/([\\w-]+)(?:\\?[\\w=&-]+)?)|' +
+        // https://youtube.com/embed/jqxENMKaeCU?cgiparam=value
+        // https://youtube-nocookie.com/jqxENMKaeCU?cgiparam=value
+        '(?:(?:(?:youtu\\.be|youtube(?:-nocookie)?\\.com/embed)/([\\w-]+)(?:\\?[\\w=&-]+)?)|' +
         // Watch URL prefix.  This should handle new URLs of the form:
         // https://www.youtube.com/watch#!v=jqxENMKaeCU&feature=related
+        // https://www.youtube-nocookie.com/watch#!v=jqxENMKaeCU&feature=related
         // where the parameters appear after "#!" instead of "?".
-        '(?:youtube\\.com/watch)' +
+        '(?:youtube(?:-nocookie)?\\.com/watch)' +
         // Get the video id:
         // The video ID is a parameter v=[videoid] either right after the "?"
         // or after some other parameters.

--- a/closure/goog/ui/media/youtube_test.js
+++ b/closure/goog/ui/media/youtube_test.js
@@ -63,7 +63,8 @@ function testParsingUrl() {
       'uddeBVmKTqE', 'http://www.youtube.com/embed/uddeBVmKTqE?controls=0');
   // a -nocookie /embed/ link
   assertExtractsCorrectly(
-      'uddeBVmKTqE', 'http://www.youtube-nocookie.com/embed/uddeBVmKTqE?controls=0');
+      'uddeBVmKTqE',
+      'http://www.youtube-nocookie.com/embed/uddeBVmKTqE?controls=0');
   // a simple short link
   assertExtractsCorrectly('uddeBVmKTqE', 'http://youtu.be/uddeBVmKTqE');
   // a secure short link

--- a/closure/goog/ui/media/youtube_test.js
+++ b/closure/goog/ui/media/youtube_test.js
@@ -55,6 +55,15 @@ function testParsingUrl() {
   // a secure mobile link
   assertExtractsCorrectly(
       'uddeBVmKTqE', 'https://m.youtube.com/watch?v=uddeBVmKTqE');
+  // a simple youtube-nocookie link
+  assertExtractsCorrectly(
+      'uddeBVmKTqE', 'http://www.youtube-nocookie.com/watch?v=uddeBVmKTqE');
+  // a simple /embed/ link
+  assertExtractsCorrectly(
+      'uddeBVmKTqE', 'http://www.youtube.com/embed/uddeBVmKTqE?controls=0');
+  // a -nocookie /embed/ link
+  assertExtractsCorrectly(
+      'uddeBVmKTqE', 'http://www.youtube-nocookie.com/embed/uddeBVmKTqE?controls=0');
   // a simple short link
   assertExtractsCorrectly('uddeBVmKTqE', 'http://youtu.be/uddeBVmKTqE');
   // a secure short link


### PR DESCRIPTION
Fixes bug where goog.ui.media.YoutubeModel throws an error on URLs like:
https://youtube-nocookie.com/jqxENMKaeCU?cgiparam=value
https://youtube.com/embed/jqxENMKaeCU?cgiparam=value