### PR TITLE
Fix the path to match the key in depsByPath Map

### DIFF
--- a/closure-deps/lib/depgraph.js
+++ b/closure-deps/lib/depgraph.js
@@ -333,8 +333,7 @@ class Graph {
   resolve_(i) {
     return i instanceof GoogRequire ?
         this.depsBySymbol.get(i.symOrPath) :
-        this.depsByPath.get(
-            this.moduleResolver.resolve(i.from.path, i.symOrPath));
+        this.depsByPath.get(i.from.path);
   }
 
   /**

--- a/closure-deps/lib/depgraph.js
+++ b/closure-deps/lib/depgraph.js
@@ -193,7 +193,7 @@ class ModuleResolver {
 class PathModuleResolver {
   /** @override */
   resolve(fromPath, importSpec) {
-    return path.join(path.dirname(fromPath), importSpec);
+    return path.resolve(path.dirname(fromPath), importSpec);
   }
 }
 
@@ -232,7 +232,7 @@ class Graph {
         throw new Error('File registered twice? ' + dep.path);
       }
       this.depsByPath.set(
-          path.join(path.dirname(dep.path), path.basename(dep.path)), dep);
+          path.join(dep.path, dep);
       for (const sym of dep.closureSymbols) {
         const previous = this.depsBySymbol.get(sym);
         if (previous) {

--- a/closure-deps/lib/depgraph.js
+++ b/closure-deps/lib/depgraph.js
@@ -193,7 +193,7 @@ class ModuleResolver {
 class PathModuleResolver {
   /** @override */
   resolve(fromPath, importSpec) {
-    return path.resolve(path.dirname(fromPath), importSpec);
+    return path.join(path.dirname(fromPath), importSpec);
   }
 }
 
@@ -231,7 +231,8 @@ class Graph {
       if (this.depsByPath.has(dep.path)) {
         throw new Error('File registered twice? ' + dep.path);
       }
-      this.depsByPath.set(dep.path, dep);
+      this.depsByPath.set(
+          path.join(path.dirname(dep.path), path.basename(dep.path)), dep);
       for (const sym of dep.closureSymbols) {
         const previous = this.depsBySymbol.get(sym);
         if (previous) {
@@ -333,7 +334,8 @@ class Graph {
   resolve_(i) {
     return i instanceof GoogRequire ?
         this.depsBySymbol.get(i.symOrPath) :
-        this.depsByPath.get(i.from.path);
+        this.depsByPath.get(
+            this.moduleResolver.resolve(i.from.path, i.symOrPath));
   }
 
   /**

--- a/closure-deps/lib/depgraph.js
+++ b/closure-deps/lib/depgraph.js
@@ -39,12 +39,12 @@ const DependencyType = {
 class Dependency {
   /**
    * @param {!DependencyType} type
-   * @param {string} path
+   * @param {string} filepath
    * @param {!Array<string>} closureSymbols
    * @param {!Array<!Import>} imports
    * @param {string=} language
    */
-  constructor(type, path, closureSymbols, imports, language = "es3") {
+  constructor(type, filepath, closureSymbols, imports, language = "es3") {
     /** @const */
     this.type = type;
 
@@ -52,7 +52,7 @@ class Dependency {
      * Full path of this file on disc.
      * @const
      */
-    this.path = path;
+    this.path = path.resolve(filepath);
 
     /**
      * Array of Closure symbols this file provides.

--- a/closure-deps/lib/depgraph.js
+++ b/closure-deps/lib/depgraph.js
@@ -231,8 +231,7 @@ class Graph {
       if (this.depsByPath.has(dep.path)) {
         throw new Error('File registered twice? ' + dep.path);
       }
-      this.depsByPath.set(
-          path.join(dep.path, dep);
+      this.depsByPath.set(dep.path, dep);
       for (const sym of dep.closureSymbols) {
         const previous = this.depsBySymbol.get(sym);
         if (previous) {


### PR DESCRIPTION
In the depsByPath Map,  the key uses the path defined in parser.parseFile().
`this.moduleResolver.resolve(i.from.path, i.symOrPath)` returns an absolute path, which causes NOT FOUND error after calling this.depsByPath.get(). The issue will be resolved by replacing it with `i.from.path`.

E.g. 
depsByPath:  Map {
  'src/js/second.js' => Dependency {
  type: 'es6 module',
  path: 'src/js/second.js',
  closureSymbols: [],
  imports: [],
  language: 'es6' }}