### PR TITLE
Efficiently copying AVL trees.

### DIFF
--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -900,8 +900,9 @@ Node.prototype.fixHeight = function() {
 };
 
 /**
- * @callback copyCb
- * @param {T}
+ * @name copyCb
+ * @function
+ * @param {T} value - A value contained by the tree.
  * @return {T}
  */
 

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -929,13 +929,18 @@ AvlTree.prototype.copy = function(copy) {
 };
 
 /**
+ * @typedef SubTree
+ * @type {object}
+ * @property {Node<T>} root - Root node of the subtree.
+ * @property {Node<T>} leftMost - Node with the smallest value in the subtree.
+ * @property {Node<T>} rightMost - Node with the largest value in the subtree.
+ */
+
+/**
  * Copies a node.
  * @param {Node<T>} parent - The parent of this node.
- * @param {copyCb=} copy - Function used to copy the values contained by the tree.
- * @return {Object} treeInfo - Information about the subtree.
- * @return {Node<T>} treeInfo.copy - Copy of the root node of this subtree.
- * @return {Node<T>} treeInfo.leftMost - Copy of the node with the smallest value in this subtree.
- * @return {Node<T>} treeInfo.rightMost - Copy of the node with the largest value in this subtree.
+ * @param {copyCb=} copy - Function used to copy the values contained by the subtree.
+ * @return {SubTree} subtree - Information about the copied subtree.
  */
 Node.prototype.copy = function(parent, copy) {
   const val = typeof copy === "function" ? copy(this.value) : JSON.parse(JSON.stringify(this.value));

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -900,15 +900,8 @@ Node.prototype.fixHeight = function() {
 };
 
 /**
- * @name copyCb
- * @function
- * @param {T} value - A value contained by the tree.
- * @return {T}
- */
-
-/**
  * Copies the AVL tree.
- * @param {copyCb=} copy - Function used to copy the values contained by the tree.
+ * @param {function(T):T} [copy] - Function used to copy the values contained by the tree.
  * @return {AvlTree<T>}
  */
 AvlTree.prototype.copy = function(copy) {
@@ -939,8 +932,8 @@ AvlTree.prototype.copy = function(copy) {
 
 /**
  * Copies a node.
- * @param {Node<T>} parent - The parent of this node.
- * @param {copyCb=} copy - Function used to copy the values contained by the subtree.
+ * @param {?Node<T>} parent - The parent of this node.
+ * @param {function(T):T} [copy] - Function used to copy the values contained by the subtree.
  * @return {SubTree} subtree - Information about the copied subtree.
  */
 Node.prototype.copy = function(parent, copy) {

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -923,18 +923,13 @@ AvlTree.prototype.copy = function(copy) {
 };
 
 /**
- * @typedef SubTree
- * @type {object}
- * @property {Node<T>} root - Root node of the subtree.
- * @property {Node<T>} leftMost - Node with the smallest value in the subtree.
- * @property {Node<T>} rightMost - Node with the largest value in the subtree.
- */
-
-/**
  * Copies a node.
  * @param {?Node<T>} parent - The parent of this node.
  * @param {function(T):T} [copy] - Function used to copy the values contained by the subtree.
- * @return {SubTree} subtree - Information about the copied subtree.
+ * @return {Object} subtree - Information about the copied subtree.
+ * @return {Node<T>} subTree.root - Root node of the subtree.
+ * @return {Node<T>} subTree.leftMost - Node with the smallest value in the subtree.
+ * @return {Node<T>} subTree.rightMost - Node with the largest value in the subtree.
  */
 Node.prototype.copy = function(parent, copy) {
   const val = typeof copy === "function" ? copy(this.value) : JSON.parse(JSON.stringify(this.value));

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -899,7 +899,18 @@ Node.prototype.fixHeight = function() {
       1;
 };
 
-AvlTree.prototype.copy = function(copyFun) {
+/**
+ * @callback copyCb
+ * @param {T}
+ * @return {T}
+ */
+
+/**
+ * Copies the AVL tree.
+ * @param {copyCb=} copy - Function used to copy the values contained by the tree.
+ * @return {AvlTree<T>}
+ */
+AvlTree.prototype.copy = function(copy) {
   const tree = new AvlTree();
   tree.comparator_ = this.comparator_;
 
@@ -909,8 +920,8 @@ AvlTree.prototype.copy = function(copyFun) {
   }
 
   // Copy instance properties
-  const {copy, leftMost, rightMost} = this.root_.copy(null, copyFun);
-  tree.root_ = copy;
+  const {root, leftMost, rightMost} = this.root_.copy(null, copy);
+  tree.root_ = root;
   tree.minNode_ = leftMost;
   tree.maxNode_ = rightMost;
 
@@ -918,15 +929,16 @@ AvlTree.prototype.copy = function(copyFun) {
 };
 
 /**
- * Deep copies a node.
- * @param {Node} parent - The parent of this node.
+ * Copies a node.
+ * @param {Node<T>} parent - The parent of this node.
+ * @param {copyCb=} copy - Function used to copy the values contained by the tree.
  * @return {Object} treeInfo - Information about the subtree.
- * @return {Node} treeInfo.copy - Copy of the root node of this subtree.
- * @return {Node} treeInfo.leftMost - Copy of the node with the smallest value in this subtree.
- * @return {Node} treeInfo.rightMost - Copy of the node with the largest value in this subtree.
+ * @return {Node<T>} treeInfo.copy - Copy of the root node of this subtree.
+ * @return {Node<T>} treeInfo.leftMost - Copy of the node with the smallest value in this subtree.
+ * @return {Node<T>} treeInfo.rightMost - Copy of the node with the largest value in this subtree.
  */
-Node.prototype.copy = function(parent, copyFun) {
-  const val = typeof copyFun === "function" ? copyFun(this.value) : JSON.parse(JSON.stringify(this.value));
+Node.prototype.copy = function(parent, copy) {
+  const val = typeof copy === "function" ? copy(this.value) : JSON.parse(JSON.stringify(this.value));
   const node = new Node(val, parent);
 
   // Copy all properties
@@ -936,18 +948,18 @@ Node.prototype.copy = function(parent, copyFun) {
   let minNode = node, maxNode = node;
 
   if (this.left) {
-    const {copy, leftMost, rightMost} = this.left.copy(node, copyFun);
-    node.left = copy;
+    const {root, leftMost, rightMost} = this.left.copy(node, copy);
+    node.left = root;
     minNode = leftMost;
   }
 
   if (this.right) {
-    const {copy, leftMost, rightMost} = this.right.copy(node, copyFun);
-    node.right = copy;
+    const {root, leftMost, rightMost} = this.right.copy(node, copy);
+    node.right = root;
     maxNode = rightMost;
   }
 
-  return {copy: node, leftMost: minNode, rightMost: maxNode};
+  return {root: node, leftMost: minNode, rightMost: maxNode};
 };
 
 exports = AvlTree;

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -920,8 +920,8 @@ AvlTree.prototype.copy = function(copyFun) {
  * @return {Node} treeInfo.leftMost - Copy of the node with the smallest value in this subtree.
  * @return {Node} treeInfo.rightMost - Copy of the node with the largest value in this subtree.
  */
-Node.prototype.copy = function(parent, copy) {
-  const val  = copy(this.value);
+Node.prototype.copy = function(parent, copyFun) {
+  const val  = typeof copyFun === "function" ? copyFun(this.value) : JSON.parse(JSON.stringify(this.value));
   const node = new Node(val, parent);
 
   // Copy all properties
@@ -931,13 +931,13 @@ Node.prototype.copy = function(parent, copy) {
   var minNode = node, maxNode = node;
 
   if (this.left) {
-    const {copy, leftMost, rightMost} = this.left.copy(node, copy);
+    const {copy, leftMost, rightMost} = this.left.copy(node, copyFun);
     node.left = copy;
     minNode = leftMost;
   }
 
   if (this.right) {
-    const {copy, leftMost, rightMost} = this.right.copy(node, copy);
+    const {copy, leftMost, rightMost} = this.right.copy(node, copyFun);
     node.right = copy;
     maxNode = rightMost;
   }

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -901,13 +901,18 @@ Node.prototype.fixHeight = function() {
 
 AvlTree.prototype.copy = function(copyFun) {
   const tree = new AvlTree();
+  tree.comparator_ = this.comparator_;
+
+  // Empty tree
+  if (!this.root_) {
+    return tree;
+  }
 
   // Copy instance properties
   const {copy, leftMost, rightMost} = this.root_.copy(null, copyFun);
-  tree.root_       = copy;
-  tree.comparator_ = this.comparator_;
-  tree.minNode_    = leftMost;
-  tree.maxNode_    = rightMost;
+  tree.root_ = copy;
+  tree.minNode_ = leftMost;
+  tree.maxNode_ = rightMost;
 
   return tree;
 };
@@ -921,14 +926,14 @@ AvlTree.prototype.copy = function(copyFun) {
  * @return {Node} treeInfo.rightMost - Copy of the node with the largest value in this subtree.
  */
 Node.prototype.copy = function(parent, copyFun) {
-  const val  = typeof copyFun === "function" ? copyFun(this.value) : JSON.parse(JSON.stringify(this.value));
+  const val = typeof copyFun === "function" ? copyFun(this.value) : JSON.parse(JSON.stringify(this.value));
   const node = new Node(val, parent);
 
   // Copy all properties
   node.count  = this.count;
   node.height = this.height;
 
-  var minNode = node, maxNode = node;
+  let minNode = node, maxNode = node;
 
   if (this.left) {
     const {copy, leftMost, rightMost} = this.left.copy(node, copyFun);

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -899,16 +899,11 @@ Node.prototype.fixHeight = function() {
       1;
 };
 
-/**
- * Returns a deep copy of the tree in O(n * k),
- * where k is the time complexity to copy a node.
- * @return {AvlTree}
- */
-AvlTree.prototype.copy = function() {
+AvlTree.prototype.copy = function(copyFun) {
   const tree = new AvlTree();
 
   // Copy instance properties
-  const {copy, leftMost, rightMost} = this.root_.copy();
+  const {copy, leftMost, rightMost} = this.root_.copy(null, copyFun);
   tree.root_       = copy;
   tree.comparator_ = this.comparator_;
   tree.minNode_    = leftMost;
@@ -917,8 +912,16 @@ AvlTree.prototype.copy = function() {
   return tree;
 };
 
-Node.prototype.copy = function(parent) {
-  const val  = JSON.parse(JSON.stringify(this.value)); // deep copy
+/**
+ * Deep copies a node.
+ * @param {Node} parent - The parent of this node.
+ * @return {Object} treeInfo - Information about the subtree.
+ * @return {Node} treeInfo.copy - Copy of the root node of this subtree.
+ * @return {Node} treeInfo.leftMost - Copy of the node with the smallest value in this subtree.
+ * @return {Node} treeInfo.rightMost - Copy of the node with the largest value in this subtree.
+ */
+Node.prototype.copy = function(parent, copy) {
+  const val  = copy(this.value);
   const node = new Node(val, parent);
 
   // Copy all properties
@@ -928,15 +931,15 @@ Node.prototype.copy = function(parent) {
   var minNode = node, maxNode = node;
 
   if (this.left) {
-      const {copy, leftMost, rightMost} = this.left.copy(node);
-      node.left = copy;
-      minNode = leftMost;
+    const {copy, leftMost, rightMost} = this.left.copy(node, copy);
+    node.left = copy;
+    minNode = leftMost;
   }
 
   if (this.right) {
-      const {copy, leftMost, rightMost} = this.right.copy(node);
-      node.right = copy;
-      maxNode = rightMost;
+    const {copy, leftMost, rightMost} = this.right.copy(node, copy);
+    node.right = copy;
+    maxNode = rightMost;
   }
 
   return {copy: node, leftMost: minNode, rightMost: maxNode};

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -905,7 +905,7 @@ Node.prototype.fixHeight = function() {
  * @return {AvlTree}
  */
 AvlTree.prototype.copy = function() {
-  const tree = new goog.structs.AvlTree();
+  const tree = new AvlTree();
 
   // Copy instance properties
   const {copy, leftMost, rightMost} = this.root_.copy();

--- a/closure/goog/structs/avltree.js
+++ b/closure/goog/structs/avltree.js
@@ -37,6 +37,7 @@
  * - getValues              O(n)
  * - inOrderTraverse        O(logn + k), where k is number of traversed nodes
  * - reverseOrderTraverse   O(logn + k), where k is number of traversed nodes
+ * - copy                   O(n * k), where k is the time complexity to copy a node
  * </pre>
  */
 
@@ -896,6 +897,49 @@ Node.prototype.fixHeight = function() {
                     this.left ? this.left.height : 0,
                     this.right ? this.right.height : 0) +
       1;
+};
+
+/**
+ * Returns a deep copy of the tree in O(n * k),
+ * where k is the time complexity to copy a node.
+ * @return {AvlTree}
+ */
+AvlTree.prototype.copy = function() {
+  const tree = new goog.structs.AvlTree();
+
+  // Copy instance properties
+  const {copy, leftMost, rightMost} = this.root_.copy();
+  tree.root_       = copy;
+  tree.comparator_ = this.comparator_;
+  tree.minNode_    = leftMost;
+  tree.maxNode_    = rightMost;
+
+  return tree;
+};
+
+Node.prototype.copy = function(parent) {
+  const val  = JSON.parse(JSON.stringify(this.value)); // deep copy
+  const node = new Node(val, parent);
+
+  // Copy all properties
+  node.count  = this.count;
+  node.height = this.height;
+
+  var minNode = node, maxNode = node;
+
+  if (this.left) {
+      const {copy, leftMost, rightMost} = this.left.copy(node);
+      node.left = copy;
+      minNode = leftMost;
+  }
+
+  if (this.right) {
+      const {copy, leftMost, rightMost} = this.right.copy(node);
+      node.right = copy;
+      maxNode = rightMost;
+  }
+
+  return {copy: node, leftMost: minNode, rightMost: maxNode};
 };
 
 exports = AvlTree;

--- a/closure/goog/structs/avltree_test.js
+++ b/closure/goog/structs/avltree_test.js
@@ -645,7 +645,7 @@ function testCopy() {
 
   tree.remove(0);
 
-  tree = tree.copy();
+  tree = tree.copy(v => v);
 
   assertEquals(3, tree.getHeight());
   assertEquals(112, tree.root_.value);

--- a/closure/goog/structs/avltree_test.js
+++ b/closure/goog/structs/avltree_test.js
@@ -647,14 +647,6 @@ function testCopy() {
 
   tree = tree.copy();
 
-  //   100                            100                             112
-  //   / \                            / \                            /  \
-  // 50   150   Right Rotate (150)   50  112      Left Rotate(100)  100  150
-  //     /   \   - - - - - - - ->           \     - - - - - - - ->  /   /   \
-  //    112  200                            150                    50   125  200
-  //     \                                  /  \
-  //     125                               125 200
-
   assertEquals(3, tree.getHeight());
   assertEquals(112, tree.root_.value);
   assertEquals(100, tree.root_.left.value);

--- a/closure/goog/structs/avltree_test.js
+++ b/closure/goog/structs/avltree_test.js
@@ -631,6 +631,45 @@ function testRemoveRightLeftCase() {
 
 
 /**
+ * This test verifies that the copy functionality works correctly.
+ */
+function testCopy() {
+  var tree = new goog.structs.AvlTree((a, b) => a - b);
+  tree.add(100);
+  tree.add(150);
+  tree.add(50);
+  tree.add(0);
+  tree.add(112);
+  tree.add(200);
+  tree.add(125);
+
+  tree.remove(0);
+
+  tree = tree.copy();
+
+  //   100                            100                             112
+  //   / \                            / \                            /  \
+  // 50   150   Right Rotate (150)   50  112      Left Rotate(100)  100  150
+  //     /   \   - - - - - - - ->           \     - - - - - - - ->  /   /   \
+  //    112  200                            150                    50   125  200
+  //     \                                  /  \
+  //     125                               125 200
+
+  assertEquals(3, tree.getHeight());
+  assertEquals(112, tree.root_.value);
+  assertEquals(100, tree.root_.left.value);
+  assertEquals(50, tree.root_.left.left.value);
+  assertEquals(150, tree.root_.right.value);
+  assertEquals(125, tree.root_.right.left.value);
+  assertEquals(200, tree.root_.right.right.value);
+
+  assertEquals(50, tree.getMinimum());
+  assertEquals(200, tree.getMaximum());
+  assertEquals(6, tree.getCount());
+}
+
+
+/**
  * Asserts expected properties of an AVL tree.
  *
  * @param {function(?, ?): number} comparator

--- a/closure/goog/structs/avltree_test.js
+++ b/closure/goog/structs/avltree_test.js
@@ -634,7 +634,7 @@ function testRemoveRightLeftCase() {
  * This test verifies that the copy functionality works correctly.
  */
 function testCopy() {
-  var tree = new goog.structs.AvlTree((a, b) => a - b);
+  let tree = new goog.structs.AvlTree((a, b) => a - b);
   tree.add(100);
   tree.add(150);
   tree.add(50);
@@ -658,6 +658,15 @@ function testCopy() {
   assertEquals(50, tree.getMinimum());
   assertEquals(200, tree.getMaximum());
   assertEquals(6, tree.getCount());
+}
+
+
+function testCopyEmptyTree() {
+  let tree = new goog.structs.AvlTree();
+  tree = tree.copy();
+
+  assertEquals(0, tree.getCount());
+  assertEquals(0, tree.getHeight());
 }
 
 


### PR DESCRIPTION
Currently the `AvlTree` does not provide a way to efficiently make a deep copy of the tree.
Hence, programmers need to fetch all values, manually deep copy the values, and then insert them in the new tree:

```
const tree = new goog.structs.AvlTree();
// ...
const copy = new goog.structs.AvlTree();

// Inneficient deep copy: O(n * k * log(n)),
// where k is the time complexity to copy a value
tree.getValues()
    .forEach(v => copy.add(JSON.parse(JSON.stringify(v))));
```

The above approach is inneficient since it is in `O(n * k * log(n))`, where `k` is the time complexity to copy a value contained by the tree.

This pull request extends the `AvlTree` with a `copy` method which deep copies the tree in `O(n * k)`.