### PR TITLE
Fix google-closure-deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 node_modules/
 closure-deps/node_modules/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 # See the LICENSE file for details.
 
 language: node_js
+node_js:
+  - "8"
 sudo: required
 
 # This is required for Java 8 in non-java image

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ dist: trusty
 cache:
   directories:
     - node_modules
+    - closure-deps/node_modules
 
 install:
   # We need jdk8 for JsDossier; but this needs to come first because
@@ -37,6 +38,7 @@ script:
   - ./scripts/ci/compile_closure.sh
   - ./scripts/ci/lint_pull_request.sh
   - ./scripts/ci/check_code_format.sh
+  - ./scripts/ci/test_closuredeps.sh
   # Disable unit tests
   # - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_wait 30 ./scripts/ci/run_all_tests.sh; fi'
 

--- a/closure-deps/package.json
+++ b/closure-deps/package.json
@@ -33,11 +33,12 @@
   },
   "homepage": "https://developers.google.com/closure/library/",
   "devDependencies": {
-    "google-closure-library": "^20180805.0.0",
-    "jasmine": "^2.9.0"
+    "google-closure-library": "^20180716.0.0",
+    "jasmine": "^2.9.0",
+    "jasmine-diff": "^0.1.3"
   },
   "dependencies": {
     "argparse": "^1.0.9",
-    "google-closure-compiler": "^20180805.0.0"
+    "google-closure-compiler": "^20181008.0.0"
   }
 }

--- a/scripts/ci/install_closure_deps.sh
+++ b/scripts/ci/install_closure_deps.sh
@@ -58,3 +58,7 @@ npm install
 
 # Install Selenium.
 ./node_modules/protractor/bin/webdriver-manager update
+
+# Install dependencies in closure-deps
+cd closure-deps
+npm install

--- a/scripts/ci/test_closuredeps.sh
+++ b/scripts/ci/test_closuredeps.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Copyright 2018 The Closure Library Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Script to determine if .js files in Pull Request are properly formatted.
+# Exits with non 0 exit code if formatting is needed.
+
+set -e
+cd closure-deps
+npm test

--- a/scripts/ci/test_closuredeps.sh
+++ b/scripts/ci/test_closuredeps.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Script to determine if .js files in Pull Request are properly formatted.
-# Exits with non 0 exit code if formatting is needed.
+# Script to test google-closure-deps package
 
 set -e
 cd closure-deps


### PR DESCRIPTION
- Update `google-closure-compiler` to pass tests using `goog.declareModuleId()` (since v20181008)
- Downgrade `google-closure-library` in devDeps to pass `closuremakedeps_test.js`
    - #862 removes useless files like `*_test.js` from published npm package in v20180805
- Add missing `jasmine-diff` to devDeps
- Run tests in Travis CI