### PR TITLE
Add yargs as a dependency

### DIFF
--- a/closure-deps/package.json
+++ b/closure-deps/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.9",
-    "google-closure-compiler": "^20181008.0.0"
+    "google-closure-compiler": "^20181008.0.0",
+    "yargs": "^12.0.2"
   }
 }


### PR DESCRIPTION
Planning on switching from argparse to yargs:

1) Yargs is much nicer to use
2) Yargs is more popular
3) Yargs has better documentation
4) Yargs has a cute pirate theme