### PR TITLE
Fix inconsistent types in goog.net.IeCorsXhrAdapter and goog.ui.CusomColorPalette

### DIFF
--- a/closure/goog/net/corsxmlhttpfactory.js
+++ b/closure/goog/net/corsxmlhttpfactory.js
@@ -93,7 +93,7 @@ goog.net.IeCorsXhrAdapter = function() {
 
   /**
    * The simulated ready state change callback function.
-   * @type {Function}
+   * @type {function()|null|undefined}
    */
   this.onreadystatechange = null;
 

--- a/closure/goog/ui/customcolorpalette.js
+++ b/closure/goog/ui/customcolorpalette.js
@@ -53,7 +53,7 @@ goog.inherits(goog.ui.CustomColorPalette, goog.ui.ColorPalette);
 /**
  * Returns an array of DOM nodes for each color, and an additional cell with a
  * '+'.
- * @return {!Array<Node>} Array of div elements.
+ * @return {!Array<!Node>} Array of div elements.
  * @override
  */
 goog.ui.CustomColorPalette.prototype.createColorNodes = function() {


### PR DESCRIPTION
The each child type has inconsistent prop type with the parent class or interface.

https://github.com/google/closure-library/blob/6175447eed18afe358943d0a914cc01a94d7e375/closure/goog/net/xhrlike.js#L37-L41

https://github.com/google/closure-library/blob/6175447eed18afe358943d0a914cc01a94d7e375/closure/goog/ui/colorpalette.js#L140-L144

Also this causes errors in TypeScript with Clutz.