### PR TITLE
Fix closure-deps to allow latest compiler

### DIFF
--- a/closure-deps/package.json
+++ b/closure-deps/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.9",
-    "google-closure-compiler": "^20181008.0.0",
+    "google-closure-compiler": ">=20181008.0.0",
     "yargs": "^12.0.2"
   }
 }


### PR DESCRIPTION
Currently closure-deps allows only closure-compiler v20181008 and doesn't follow latest compiler.
Also if I use latest compiler and closure-deps in my project, the node_modules have two compiler versions.
This PR widdens the range of compiler version for the problem.

Another solution is updating the compiler version in the deps and publishing closure-deps for every compiler release.