### PR TITLE
Check for null when checking typeof websocket opt_params != object

### DIFF
--- a/closure/goog/net/websocket.js
+++ b/closure/goog/net/websocket.js
@@ -62,7 +62,7 @@ goog.require('goog.log');
  */
 goog.net.WebSocket = function(opt_params, opt_getNextReconnect) {
   goog.net.WebSocket.base(this, 'constructor');
-  if (typeof opt_params != 'object') {
+  if (typeof opt_params != 'object' || opt_params === null) {
     opt_params = /**@type {!goog.net.WebSocket.Options} */ ({
       autoReconnect: opt_params,
       getNextReconnect: opt_getNextReconnect,


### PR DESCRIPTION
I'm running into issues with a ClojureScript project that is passing null for opt_params. Since `typeof null` is "object," opt_params doesn't get initialized to the default value. I think the argument can be made that the change should be not to pass null to goog.net.WebSocket, but I think null should explicitly be checked for when testing using typeof and object in a conditional.