### PR TITLE
Fix creating emoji url using id when prefixUrl exists

### DIFF
--- a/closure/goog/ui/emoji/emojipicker.js
+++ b/closure/goog/ui/emoji/emojipicker.js
@@ -680,7 +680,7 @@ goog.ui.emoji.EmojiPicker.prototype.getSelectedEmoji = function() {
                  this.urlPrefix_ + this.selectedEmoji_.getUrl(),
                  this.selectedEmoji_.getId()) :
              this.selectedEmoji_;
-
+};
 
 /**
  * Returns the number of emoji groups in this picker.

--- a/closure/goog/ui/emoji/emojipicker.js
+++ b/closure/goog/ui/emoji/emojipicker.js
@@ -675,11 +675,11 @@ goog.ui.emoji.EmojiPicker.prototype.getCssClass = function() {
  * @return {goog.ui.emoji.Emoji} The currently selected emoji from this picker.
  */
 goog.ui.emoji.EmojiPicker.prototype.getSelectedEmoji = function() {
-  return this.urlPrefix_ ? new goog.ui.emoji.Emoji(
-                               this.urlPrefix_ + this.selectedEmoji_.getUrl(),
-                               this.selectedEmoji_.getId()) :
-                           this.selectedEmoji_;
-};
+  return this.urlPrefix_ ?
+             new goog.ui.emoji.Emoji(
+                 this.urlPrefix_ + this.selectedEmoji_.getUrl(),
+                 this.selectedEmoji_.getId()) :
+             this.selectedEmoji_;
 
 
 /**

--- a/closure/goog/ui/emoji/emojipicker.js
+++ b/closure/goog/ui/emoji/emojipicker.js
@@ -677,7 +677,7 @@ goog.ui.emoji.EmojiPicker.prototype.getCssClass = function() {
 goog.ui.emoji.EmojiPicker.prototype.getSelectedEmoji = function() {
   return this.urlPrefix_ ?
       new goog.ui.emoji.Emoji(
-          this.urlPrefix_ + this.selectedEmoji_.getId(),
+          this.urlPrefix_ + this.selectedEmoji_.getUrl(),
           this.selectedEmoji_.getId()) :
       this.selectedEmoji_;
 };

--- a/closure/goog/ui/emoji/emojipicker.js
+++ b/closure/goog/ui/emoji/emojipicker.js
@@ -675,11 +675,10 @@ goog.ui.emoji.EmojiPicker.prototype.getCssClass = function() {
  * @return {goog.ui.emoji.Emoji} The currently selected emoji from this picker.
  */
 goog.ui.emoji.EmojiPicker.prototype.getSelectedEmoji = function() {
-  return this.urlPrefix_ ?
-      new goog.ui.emoji.Emoji(
-          this.urlPrefix_ + this.selectedEmoji_.getUrl(),
-          this.selectedEmoji_.getId()) :
-      this.selectedEmoji_;
+  return this.urlPrefix_ ? new goog.ui.emoji.Emoji(
+                               this.urlPrefix_ + this.selectedEmoji_.getUrl(),
+                               this.selectedEmoji_.getId()) :
+                           this.selectedEmoji_;
 };
 
 

--- a/closure/goog/ui/emoji/emojipicker_test.js
+++ b/closure/goog/ui/emoji/emojipicker_test.js
@@ -810,6 +810,30 @@ testSuite({
     picker.dispose();
   },
 
+  testGetSelectedEmoji_urlPrefix() {
+    const defaultImg = 'http://example.com/../../demos/emoji/none.gif';
+    const picker = new EmojiPicker(defaultImg);
+    picker.setDelayedLoad(false);
+    picker.addEmojiGroup(emojiGroup1[0], emojiGroup1[1]);
+    picker.setUrlPrefix('http://example.com/')
+    picker.render();
+
+    const palette = picker.getPage(0);
+
+    // No emoji should be selected yet
+    assertUndefined(palette.getSelectedEmoji());
+
+    // Artificially select the first emoji
+    palette.setSelectedIndex(0);
+
+    // Now we should get the first emoji back. See emojiGroup1 above.
+    const emoji = palette.getSelectedEmoji();
+    assertEquals(emoji.getId(), 'std.200');
+    assertEquals(emoji.getUrl(), 'http://example.com/../../demos/emoji/200.gif');
+
+    picker.dispose();
+  },
+
   testPreLoadCellConstructionForFastLoadingNonProgressive() {
     const defaultImg = '../../demos/emoji/none.gif';
     const picker = new EmojiPicker(defaultImg);

--- a/closure/goog/ui/emoji/emojipicker_test.js
+++ b/closure/goog/ui/emoji/emojipicker_test.js
@@ -811,26 +811,22 @@ testSuite({
   },
 
   testGetSelectedEmoji_urlPrefix() {
-    const defaultImg = 'http://example.com/../../demos/emoji/none.gif';
+    const defaultImg = 'a/b/../../../../demos/emoji/none.gif';
     const picker = new EmojiPicker(defaultImg);
     picker.setDelayedLoad(false);
     picker.addEmojiGroup(emojiGroup1[0], emojiGroup1[1]);
-    picker.setUrlPrefix('http://example.com/')
+    picker.setUrlPrefix('a/b/../../');
     picker.render();
 
     const palette = picker.getPage(0);
-
-    // No emoji should be selected yet
-    assertUndefined(palette.getSelectedEmoji());
-
-    // Artificially select the first emoji
+    // Artificially select the an emoji
     palette.setSelectedIndex(0);
+    palette.dispatchEvent(goog.ui.Component.EventType.ACTION);
 
     // Now we should get the first emoji back. See emojiGroup1 above.
-    const emoji = palette.getSelectedEmoji();
-    assertEquals(emoji.getId(), 'std.200');
-    assertEquals(
-        emoji.getUrl(), 'http://example.com/../../demos/emoji/200.gif');
+    const emoji = picker.getSelectedEmoji();
+    assertEquals('std.200', emoji.getId());
+    assertEquals('a/b/../../../../demos/emoji/200.gif', emoji.getUrl());
 
     picker.dispose();
   },

--- a/closure/goog/ui/emoji/emojipicker_test.js
+++ b/closure/goog/ui/emoji/emojipicker_test.js
@@ -829,7 +829,8 @@ testSuite({
     // Now we should get the first emoji back. See emojiGroup1 above.
     const emoji = palette.getSelectedEmoji();
     assertEquals(emoji.getId(), 'std.200');
-    assertEquals(emoji.getUrl(), 'http://example.com/../../demos/emoji/200.gif');
+    assertEquals(
+        emoji.getUrl(), 'http://example.com/../../demos/emoji/200.gif');
 
     picker.dispose();
   },


### PR DESCRIPTION
`emojipicker.js#getSelectedEmoji` return `goog.ui.emoji.Emoji` using id when prefixUrl exists.

I checked the [demo page](https://google.github.io/closure-library/source/closure/goog/demos/) of Emoji Picker. This demo doesn't use  urlPrefix_, so working properly. If use urlPrefix_, don't work properly.
https://github.com/google/closure-library/blob/master/closure/goog/demos/popupemojipicker.html#L303

if use `urlPrefix_`, `getSelectedEmoji` returns the `goog.ui.emoji.Emoji` with the ID added to the `urlPreix`. (ex: https://foo/static/std.200)

We expect the `goog.ui.emoji.Emoji` with the URL added to the `urlPreix`(ex: https://foo/static/emoji/200.gif)



