### PR TITLE
Fix deleteW3cRange_ in enterhanderjs

### DIFF
--- a/closure/goog/editor/plugins/enterhandler.js
+++ b/closure/goog/editor/plugins/enterhandler.js
@@ -649,6 +649,8 @@ goog.editor.plugins.EnterHandler.deleteW3cRange_ = function(range) {
     var isInOneContainer =
         goog.editor.plugins.EnterHandler.isInOneContainerW3c_(range);
 
+    // Whether the selection starts in a container.
+    var isPartialStart = !isInOneContainer && range.getStartOffset() != 0;
     // Whether the selection ends in a container it doesn't fully select.
     var isPartialEnd = !isInOneContainer &&
         goog.editor.plugins.EnterHandler.isPartialEndW3c_(range);
@@ -683,7 +685,7 @@ goog.editor.plugins.EnterHandler.deleteW3cRange_ = function(range) {
       }
     }
 
-    if (isPartialEnd) {
+    if (isPartialStart && isPartialEnd) {
       /*
        This code handles the following, where | is the cursor:
          <div>a|b</div><div>c|d</div>

--- a/closure/goog/editor/plugins/enterhandler.js
+++ b/closure/goog/editor/plugins/enterhandler.js
@@ -757,6 +757,21 @@ goog.editor.plugins.EnterHandler.isInOneContainerW3c_ = function(range) {
 goog.editor.plugins.EnterHandler.isPartialEndW3c_ = function(range) {
   var endContainer = range.getEndNode();
   var endOffset = range.getEndOffset();
+  // Since the range object is different for each browser,
+  // Normalize range using previousSibling or parentNode of
+  // endContainer, when endOffset is 0.
+  while (endOffset == 0 && endContainer) {
+    if (endContainer.previousSibling) {
+      endContainer = endContainer.previousSibling;
+      endOffset = goog.editor.node.getLength(endContainer);
+    } else if (endContainer.parentNode) {
+      endContainer = endContainer.parentNode;
+      endOffset = 0;
+    } else {
+      break;
+    }
+  }
+
   var node = endContainer;
   if (goog.editor.style.isContainer(node)) {
     var child = node.childNodes[endOffset];

--- a/closure/goog/editor/plugins/enterhandler.js
+++ b/closure/goog/editor/plugins/enterhandler.js
@@ -245,7 +245,7 @@ goog.editor.plugins.EnterHandler.prototype.deleteBrGecko = function(e) {
         //    end of that.
         // 2. If the BR doesn't have a previous sibling or the previous sibling
         //    is a block level element or a BR, we place the cursor at the
-        //    leftmost of the leftmost leaf of its next sibling.
+        //    beginning of the leftmost leaf of its next sibling.
         if (nextSibling && goog.editor.node.isBlockTag(nextSibling)) {
           if (previousSibling &&
               !(previousSibling.tagName == goog.dom.TagName.BR ||

--- a/closure/goog/editor/plugins/enterhandler.js
+++ b/closure/goog/editor/plugins/enterhandler.js
@@ -245,7 +245,7 @@ goog.editor.plugins.EnterHandler.prototype.deleteBrGecko = function(e) {
         //    end of that.
         // 2. If the BR doesn't have a previous sibling or the previous sibling
         //    is a block level element or a BR, we place the cursor at the
-        //    beginning of the leftmost leaf of its next sibling.
+        //    leftmost of the leftmost leaf of its next sibling.
         if (nextSibling && goog.editor.node.isBlockTag(nextSibling)) {
           if (previousSibling &&
               !(previousSibling.tagName == goog.dom.TagName.BR ||
@@ -632,13 +632,13 @@ goog.editor.plugins.EnterHandler.prototype.deleteCursorSelectionW3C_ =
 };
 
 /**
- * Checks Whether the selection range start from beginning.
+ * Checks Whether the selection range start from leftmost.
  * @param {Node} node the element or text node the range starts in.
  * @param {Node} baseNode the container element.
- * @return {boolean} Whether the selection range start from beginning.
+ * @return {boolean} Whether the selection range start from leftmost.
  * @private
  */
-goog.editor.plugins.EnterHandler.isStartFromBeginning_ = function(node, baseNode) {
+goog.editor.plugins.EnterHandler.isNodeLeftMostChild_ = function(node, baseNode) {
   while (node && node.nodeName != goog.dom.TagName.BODY && node != baseNode) {
     if (node.previousSibling) {
       return false;
@@ -671,8 +671,8 @@ goog.editor.plugins.EnterHandler.deleteW3cRange_ = function(range) {
     var isPartialEnd = !isInOneContainer &&
         goog.editor.plugins.EnterHandler.isPartialEndW3c_(range);
 
-    var isStartFromBeginning =
-        goog.editor.plugins.EnterHandler.isStartFromBeginning_(
+    var isNodeLeftMostChild =
+        goog.editor.plugins.EnterHandler.isNodeLeftMostChild_(
             range.getStartNode(), baseNode);
 
     // Remove The range contents, and ensure the correct content stays selected.
@@ -683,9 +683,9 @@ goog.editor.plugins.EnterHandler.deleteW3cRange_ = function(range) {
     } else {
       // when the node that would have been referenced has now been deleted and
       // there are no other nodes in the baseNode,  Thus need to set the caret
-      // to the end of the base node. If selection range start from beginning,
+      // to the end of the base node. If selection range start from leftmost,
       // set the caret to the start of the base node.
-      var pos = isStartFromBeginning ? 0 : baseNode.childNodes.length;
+      var pos = isNodeLeftMostChild ? 0 : baseNode.childNodes.length;
       range = goog.dom.Range.createCaret(baseNode, pos);
       reselect = false;
     }

--- a/closure/goog/editor/plugins/enterhandler_test.js
+++ b/closure/goog/editor/plugins/enterhandler_test.js
@@ -758,4 +758,43 @@ testSuite({
       assertEquals(2, newRange.getStartOffset());
     }
   },
+
+  testDeleteW3CRemoveEntireLineWithShiftDown() {
+    if (BrowserFeature.HAS_W3C_RANGES) {
+      container.innerHTML = '<div>a</div><div>b</div><div>c</div><div>d</div>';
+      const range = Range.createFromNodes(
+          container.children[1].firstChild, 0, container.children[2],
+          0);
+      range.select();
+      EnterHandler.deleteW3cRange_(range);
+
+      testingDom.assertHtmlContentsMatch('<div>a</div><div>c</div><div>d</div>', container);
+    }
+  },
+
+  testDeleteW3CRemoveEntireFirstLineWithShiftDown() {
+    if (BrowserFeature.HAS_W3C_RANGES) {
+      container.innerHTML = '<div>a</div><div>b</div><div>c</div><div>d</div>';
+      const range = Range.createFromNodes(
+          container.children[0].firstChild, 0, container.children[1],
+          0);
+      range.select();
+      EnterHandler.deleteW3cRange_(range);
+
+      testingDom.assertHtmlContentsMatch('<div>b</div><div>c</div><div>d</div>', container);
+    }
+  },
+
+  testDeleteW3CRemoveEntireLineWithPartialSecondLine() {
+    if (BrowserFeature.HAS_W3C_RANGES) {
+      container.innerHTML = '<div>a</div><div>b</div><div>cc</div><div>d</div>';
+      const range = Range.createFromNodes(
+          container.children[1].firstChild, 0, container.children[2].firstChild,
+          1);
+      range.select();
+      EnterHandler.deleteW3cRange_(range);
+
+      testingDom.assertHtmlContentsMatch('<div>a</div><div>c</div><div>d</div>', container);
+    }
+  },
 });


### PR DESCRIPTION
Some behavior of deleteW3cRange_ is inadequate.
This behavior only happens using `Chrome`  or `Safari`.


<details><summary>concrete example</summary>

In the case of Editor Demo. `|` is the cursor.
https://google.github.io/closure-library/source/closure/goog/demos/editor/editor.html

```
a
|b|
c
d
```

type Enter...

```
a

|cd
```

Other

```
a
|b
c|c
d
```

type Enter...

```
a

|cd
```

Other

```
|a|
b
c
d
```

type Enter...

```
b
c
d
|
```
</details>

Fixes
- Normalize range in `isPartialEndW3c_ `, Since the range object is different for each browser
- Concatenate characters only when `isPartialStart` and `isPartialEnd`
- When the selection starts from the beginning, the Caret position is at the beginning
