### PR TITLE
Move promises-aplus-tests from deps to devDeps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@
 /*.json
 /closure/bin/generate_closure_unit_tests
 /closure/goog/demos/
+/closure/goog/promise/testsuiteadapter.js
 /closure-deps/
 /doc
 /scripts

--- a/package.json
+++ b/package.json
@@ -21,9 +21,8 @@
   "homepage": "https://developers.google.com/closure/library/",
   "devDependencies": {
     "promise": "^7.0.4",
+    "promises-aplus-tests": "^2.1.2",
     "protractor": "^2.1.0"
   },
-  "dependencies": {
-    "promises-aplus-tests": "^2.1.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
`promises-aplus-tests` is used only in `goog/promise/testsuiteadapter.js` that is not used in production.
It should be moved to devDependencies.

https://github.com/google/closure-library/blob/36d2c6df96b21043361b3bca4b7b5e981cb91471/closure/goog/promise/testsuiteadapter.js#L33

https://www.npmjs.com/package/google-closure-library?activeTab=dependencies

Also this PR removes `goog/promise/testsuiteadapter.js` from published npm package.
It is obviously a development-only file, as it is excluded from type checking.

https://github.com/google/closure-library/blob/36d2c6df96b21043361b3bca4b7b5e981cb91471/scripts/ci/compile_closure.sh#L41