### PR TITLE
Allow passing Uint8Array to StreamParser.parse

### DIFF
--- a/closure/goog/net/streams/jsonstreamparser.js
+++ b/closure/goog/net/streams/jsonstreamparser.js
@@ -239,7 +239,7 @@ Parser.prototype.getExtraInput = function() {
 
 
 /**
- * @param {string|!ArrayBuffer|!Array<number>} input
+ * @param {string|!ArrayBuffer|!Uint8Array|!Array<number>} input
  *     The current input string (always)
  * @param {number} pos The position in the current input that triggers the error
  * @throws {!Error} Throws an error indicating where the stream is broken

--- a/closure/goog/net/streams/streamparser.js
+++ b/closure/goog/net/streams/streamparser.js
@@ -57,7 +57,7 @@ goog.net.streams.StreamParser.prototype.getErrorMessage = goog.abstractMethod;
  *
  * Note that there is no Parser state to indicate the end of a stream.
  *
- * @param {string|!ArrayBuffer|!Array<number>} input The input data
+ * @param {string|!ArrayBuffer|!Uint8Array|!Array<number>} input The input data
  * @throws {!Error} if the input is invalid, and the parser will remain invalid
  *    once an error has been thrown.
  * @return {?Array<string|!Object>} any parsed objects (atomic messages)


### PR DESCRIPTION
This will help address issue with grpc-web described here: https://github.com/grpc/grpc-web/pull/683#issuecomment-561999180

In a nutshell, grpc-web implements StreamParser which accepts only Array or ArrayBuffer (as per the interface), but the upstream to that parser operates on UInt8Array. For various reasons (described in the link above), the upstream creates a copy of all the bytes first before passing to the parser.
this obviously is CPU and memory ineffective and for larger payloads (50+ mb) creates a browser freeze.

We can solve those problems by passing UInt8Array to the parser, but first the interface signature has to be addressed, hence this PR.