### PR TITLE
Fix grammatical mistake in JSDocs for `goog.html.SafeUrl.getTypedStringValue` and `goog.string.Const.getTypedStringValue`

### DIFF
--- a/closure/goog/html/safeurl.js
+++ b/closure/goog/html/safeurl.js
@@ -118,7 +118,7 @@ goog.html.SafeUrl.prototype.implementsGoogStringTypedString = true;
 
 
 /**
- * Returns this SafeUrl's value a string.
+ * Returns this SafeUrl's value as a string.
  *
  * IMPORTANT: In code where it is security relevant that an object's type is
  * indeed `SafeUrl`, use `goog.html.SafeUrl.unwrap` instead of this

--- a/closure/goog/string/const.js
+++ b/closure/goog/string/const.js
@@ -71,7 +71,7 @@ goog.string.Const.prototype.implementsGoogStringTypedString = true;
 
 
 /**
- * Returns this Const's value a string.
+ * Returns this Const's value as a string.
  *
  * IMPORTANT: In code where it is security-relevant that an object's type is
  * indeed `goog.string.Const`, use `goog.string.Const.unwrap`


### PR DESCRIPTION
Both JSDoc comments said:

"Returns this ... value a string"

when it should be

"Returns this ... value as a string"