### PR TITLE
Fix closurebuilder.py for Python 3

### DIFF
--- a/closure/bin/build/closurebuilder.py
+++ b/closure/bin/build/closurebuilder.py
@@ -209,12 +209,7 @@ def main():
   if options.output_file:
     out = io.open(options.output_file, 'wb')
   else:
-    version = sys.version_info[:2]
-    if version >= (3, 0):
-      # Write bytes to stdout
-      out = sys.stdout.buffer
-    else:
-      out = sys.stdout
+    out = sys.stdout
 
   sources = set()
 


### PR DESCRIPTION
Currently closurebuilder.py throws this when run in Python 3:
```
Traceback (most recent call last):
  File "third-party-downloads/build/closurebuilder.py", line 300, in <module>
    main()
  File "third-party-downloads/build/closurebuilder.py", line 260, in main
    out.writelines([js_source.GetPath() + '\n' for js_source in deps])
TypeError: a bytes-like object is required, not 'str'
```

Writing to `sys.stdout` rather than `sys.stdout.buffer` fixes this.

Reported at https://github.com/google/blockly-games/issues/195#issuecomment-715958020
Related to https://github.com/google/closure-library/issues/849, but that issue failed to actually modify closurebuilder.py