### PR TITLE
[closure-deps] Allow globs in --exclude flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   # otherwise there is no java at all.
   - jdk_switcher use oraclejdk8
   - ./scripts/ci/install_closure_deps.sh
+  - clang-format --version
 
 before_script:
   - ./scripts/http/simple_http_server.py 2> /dev/null & sleep 5

--- a/closure-deps/bin/closuremakedeps.js
+++ b/closure-deps/bin/closuremakedeps.js
@@ -24,6 +24,7 @@
 const depFile = require('../lib/depfile');
 const depGraph = require('../lib/depgraph');
 const fs = require('fs');
+const minimatch = require('minimatch');
 const parser = require('../lib/parser');
 const path = require('path');
 const process = require('process');
@@ -52,14 +53,15 @@ function parseArgs(args) {
         alias: 'f',
         default: [],
         array: true,
-        description: 'One or more input files to calculate dependencies ' +
-            'for. The namespaces in these files will be combined with ' +
-            'those given with the --root flag to form the set of ' +
-            'namespaces to find dependencies for. If this is a file that ' +
-            'contains repeated calls to goog.addDependency, then the calls ' +
-            'will be used as forward declarations. e.g. if you include ' +
-            'Closure Library\'s deps.js file, then there is no need to ' +
-            'include closure/goog/array/array.js as an input file as well. ' +
+        description:
+            'One or more input files to calculate dependencies for. The ' +
+            'namespaces in these files will be combined with those given ' +
+            'with the --root flag to form the set of namespaces to find ' +
+            'dependencies for. If this is a file that contains repeated ' +
+            'calls to goog.addDependency, then the calls will be used as ' +
+            'forward declarations. e.g. if you include Closure Library\'s ' +
+            'deps.js file, then there is no need to include ' +
+            'closure/goog/array/array.js as an input file as well. ' +
             'If you wish to merge these deps files in the output, see the ' +
             '--merge-deps option.',
       })
@@ -77,9 +79,8 @@ function parseArgs(args) {
         default: [],
         array: true,
         description:
-            'One or more path prefixes to ignore. Useful when combined ' +
-            'with the --root flag to ignore specific subfiles or ' +
-            'subdirectories.'
+            'One or more path globs to ignore. Useful when combined with the ' +
+            '--root flag to ignore specific subfiles or subdirectories.'
       })
       .option('closure-path', {
         default: undefined,
@@ -117,6 +118,16 @@ function resolve(p) {
 }
 
 /**
+ * Returns whether the given path matches at least one of the given globs.
+ * @param {!Array<string>} globs The globs against which to match.
+ * @param {string} path The path to match.
+ * @return {boolean} Whether the path matches at least one of the globs.
+ */
+function globMatch(globs, path) {
+  return globs.some(glob => minimatch(path, glob));
+}
+
+/**
  * @param {function(...?)} fn
  * @param {...?} args
  * @return {!Promise<?>}
@@ -129,11 +140,11 @@ function promisify(fn, ...args) {
 
 /**
  * @param {string} pathToScan
- * @param {!Set<string>} excluded
+ * @param {!Array<string>} excluded
  * @return {!Promise<!Array<string>>}
  */
 async function findAllJsFiles(pathToScan, excluded) {
-  if (excluded.has(pathToScan)) {
+  if (globMatch(excluded, pathToScan)) {
     return [];
   }
 
@@ -215,7 +226,7 @@ async function main(opt_args) {
 
   const sources = new Set((args.file || []).map(resolve));
   const roots = (args.root || []).map(resolve);
-  const excluded = new Set((args.exclude || []).map(resolve));
+  const excluded = (args.exclude || []).map(resolve);
 
   const allFiles =
       await Promise.all(roots.map(r => findAllJsFiles(r, excluded)));

--- a/closure-deps/package.json
+++ b/closure-deps/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.9",
+    "minimatch": "^3.0.4",
     "yargs": "^12.0.2"
   }
 }


### PR DESCRIPTION
This change adds the ability to specify globs in closuremakedeps's --exclude flag, instead of just path prefixes.