### PR TITLE
Fix README for updating `dependency` -> `dependencies`

### DIFF
--- a/closure-deps/README.md
+++ b/closure-deps/README.md
@@ -66,16 +66,16 @@ const {parser, depGraph} = require('google-closure-deps');
 
 // A file that provides "goog" is required for any file that references Closure.
 // Usually this is Closure's base.js file.
-const goog = parser.parseText('/** @provideGoog */', '/base.js').dependency;
+const goog = parser.parseText('/** @provideGoog */', '/base.js').dependencies;
 
 const firstFile =
-    parser.parseText(`goog.module('first.module')`, '/first.js').dependency;
+    parser.parseText(`goog.module('first.module')`, '/first.js').dependencies;
 const secondFile = parser.parseText(`
 goog.module('second.module');
 const firstModule = goog.require('first.module');
-`, '/second.js').dependency;
-const graph = new depGraph.Graph([goog, firstFile, secondFile]);
-graph.order(secondFile); // [goog, firstFile, secondFile]
+`, '/second.js').dependencies;
+const graph = new depGraph.Graph([...goog, ...firstFile, ...secondFile]);
+graph.order(...secondFile); // [goog, firstFile, secondFile]
 graph.depsBySymbol.get('first.module'); // firstFile
 graph.depsByPath.get('/second.js'); // secondFile
 ```
@@ -88,25 +88,25 @@ const {parser, depGraph} = require('google-closure-deps');
 
 // A file that provides "goog" is required for any file that references Closure.
 // Usually this is Closure's base.js file.
-const goog = parser.parseText('/** @provideGoog */', '/base.js').dependency;
+const goog = parser.parseText('/** @provideGoog */', '/base.js').dependencies;
 
 const firstFile = parser.parseText(
 `
 goog.declareModuleId('first.module');
 export const FOO = 'foo';
-`, "/first.js").dependency;
+`, "/first.js").dependencies;
 
 const secondFile = parser.parseText(
     'import {FOO} from "./first.js";',
-    '/second.js').dependency;
+    '/second.js').dependencies;
 
 const thirdFile = parser.parseText(
 `
 goog.module("third.module");
 const firstModule = goog.require("first.module");
-`, '/third.js').dependency;
+`, '/third.js').dependencies;
 
-const graph = new depGraph.Graph([goog, firstFile, secondFile, thirdFile]);
-graph.order(secondFile, thirdFile); // [goog, firstFile, secondFile, thirdFile]
+const graph = new depGraph.Graph([...goog, ...firstFile, ...secondFile, ...thirdFile]);
+graph.order(...secondFile, ...thirdFile); // [goog, firstFile, secondFile, thirdFile]
 ```
 


### PR DESCRIPTION
Sorry I'm not familiar with Closure well. But codes listed in the README of closure-deps do not work now. I think it's because the `dependency` of `ParseResult` has been changed to `dependencies` since https://github.com/google/closure-library/commit/7310b1ba7889cf1b137c65782b2f86956d736284.

