### PR TITLE
Added webkitFullscreenEnabled check in goog.dom.fullscreen.isSupported

### DIFF
--- a/closure/goog/dom/fullscreen.js
+++ b/closure/goog/dom/fullscreen.js
@@ -73,7 +73,7 @@ goog.dom.fullscreen.isSupported = function(opt_domHelper) {
   var doc = goog.dom.fullscreen.getDocument_(opt_domHelper);
   var body = doc.body;
   return !!(
-      body.webkitRequestFullscreen ||
+      (body.webkitRequestFullscreen && doc.webkitFullscreenEnabled) ||
       (body.mozRequestFullScreen && doc.mozFullScreenEnabled) ||
       (body.msRequestFullscreen && doc.msFullscreenEnabled) ||
       (body.requestFullscreen && doc.fullscreenEnabled));


### PR DESCRIPTION
Link to the issue: https://github.com/google/closure-library/issues/1140
Included `webkitFullscreenEnabled` to prevent false positive results.
Check https://developer.apple.com/documentation/webkitjs/document/1630333-webkitfullscreenenabled for more info about `webkitFullscreenEnabled`. 