### PR TITLE
Harmonize currency format for DACH region

### DIFF
--- a/closure/goog/i18n/numberformatsymbols.js
+++ b/closure/goog/i18n/numberformatsymbols.js
@@ -576,7 +576,7 @@ goog.i18n.NumberFormatSymbols_de = {
   DECIMAL_PATTERN: '#,##0.###',
   SCIENTIFIC_PATTERN: '#E0',
   PERCENT_PATTERN: '#,##0 %',
-  CURRENCY_PATTERN: '#,##0.00 ¤;-#,##0.00 ¤',
+  CURRENCY_PATTERN: '#,##0.00 ¤;-#,##0.00 ¤',
   DEF_CURRENCY_CODE: 'EUR'
 };
 
@@ -599,7 +599,7 @@ goog.i18n.NumberFormatSymbols_de_AT = {
   DECIMAL_PATTERN: '#,##0.###',
   SCIENTIFIC_PATTERN: '#E0',
   PERCENT_PATTERN: '#,##0 %',
-  CURRENCY_PATTERN: '#,##0.00 ¤;-#,##0.00 ¤',
+  CURRENCY_PATTERN: '#,##0.00 ¤;-#,##0.00 ¤',
   DEF_CURRENCY_CODE: 'EUR'
 };
 
@@ -622,7 +622,7 @@ goog.i18n.NumberFormatSymbols_de_CH = {
   DECIMAL_PATTERN: '#,##0.###',
   SCIENTIFIC_PATTERN: '#E0',
   PERCENT_PATTERN: '#,##0%',
-  CURRENCY_PATTERN: '#,##0.00 ¤;-#,##0.00 ¤',
+  CURRENCY_PATTERN: '#,##0.00 ¤;-#,##0.00 ¤',
   DEF_CURRENCY_CODE: 'CHF'
 };
 


### PR DESCRIPTION
Apply the most common format for currency strings to "de", "de-AT", "de-CH". 
First sign, then value, then currency symbol/code.

Fixes #1144