### PR TITLE
Fix a comment in heap.js

### DIFF
--- a/closure/goog/structs/heap.js
+++ b/closure/goog/structs/heap.js
@@ -199,7 +199,7 @@ goog.structs.Heap.prototype.moveUp_ = function(index) {
 
   // While the node being moved up is not at the root.
   while (index > 0) {
-    // If the parent is less than the node being moved up, move the parent down.
+    // If the parent is greater than the node being moved up, move the parent down.
     var parentIndex = this.getParentIndex_(index);
     if (nodes[parentIndex].getKey() > node.getKey()) {
       nodes[index] = nodes[parentIndex];


### PR DESCRIPTION
In a min heap, where smaller keys rise to the top, the up-heap operation should move the parent of a node down if the parent is _greater_ than the node.