### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/closure/goog/base.js
+++ b/closure/goog/base.js
@@ -2238,8 +2238,8 @@ if (!COMPILED && goog.DEPENDENCIES_ENABLED) {
       var src = script.src;
       var qmark = src.lastIndexOf('?');
       var l = qmark == -1 ? src.length : qmark;
-      if (src.substr(l - 7, 7) == 'base.js') {
-        goog.basePath = src.substr(0, l - 7);
+      if (src.slice(l - 7, l) == 'base.js') {
+        goog.basePath = src.slice(0, l - 7);
         return;
       }
     }

--- a/closure/goog/color/alpha.js
+++ b/closure/goog/color/alpha.js
@@ -148,10 +148,10 @@ goog.color.alpha.hexToRgba = function(hexColor) {
   // TODO(user): Enhance code sharing with goog.color, for example by
   //     adding a goog.color.genericHexToRgb method.
   hexColor = goog.color.alpha.normalizeAlphaHex_(hexColor);
-  const r = parseInt(hexColor.substr(1, 2), 16);
-  const g = parseInt(hexColor.substr(3, 2), 16);
-  const b = parseInt(hexColor.substr(5, 2), 16);
-  const a = parseInt(hexColor.substr(7, 2), 16);
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+  const a = parseInt(hexColor.slice(7, 9), 16);
 
   return [r, g, b, a / 255];
 };

--- a/closure/goog/color/color.js
+++ b/closure/goog/color/color.js
@@ -161,7 +161,7 @@ goog.color.normalizeHex = function(hexColor) {
 goog.color.hexToRgb = function(hexColor) {
   'use strict';
   hexColor = goog.color.normalizeHex(hexColor);
-  const rgb = parseInt(hexColor.substr(1), 16);
+  const rgb = parseInt(hexColor.slice(1), 16);
   const r = rgb >> 16;
   const g = (rgb >> 8) & 255;
   const b = rgb & 255;
@@ -187,7 +187,7 @@ goog.color.rgbToHex = function(r, g, b) {
   }
   const rgb = (r << 16) | (g << 8) | b;
   if (r < 0x10) {
-    return '#' + (0x1000000 | rgb).toString(16).substr(1);
+    return '#' + (0x1000000 | rgb).toString(16).slice(1);
   }
   return '#' + rgb.toString(16);
 };

--- a/closure/goog/crypt/blobhasher_test.js
+++ b/closure/goog/crypt/blobhasher_test.js
@@ -36,7 +36,7 @@ class BlobMock {
   }
 
   slice(start, end) {
-    return new BlobMock(this.data.substr(start, end - start));
+    return new BlobMock(this.data.slice(start, end));
   }
 }
 

--- a/closure/goog/crypt/md5_test.js
+++ b/closure/goog/crypt/md5_test.js
@@ -70,7 +70,7 @@ testSuite({
     // Message + padding fits in two 64-byte blocks.
     const md5 = new Md5();
     md5.update(sixty);
-    md5.update(sixty.substr(0, 59));
+    md5.update(sixty.slice(0, 59));
     assertEquals(
         '6261005311809757906e04c0d670492d', crypt.byteArrayToHex(md5.digest()));
 

--- a/closure/goog/debug/debug.js
+++ b/closure/goog/debug/debug.js
@@ -616,7 +616,7 @@ goog.debug.getStacktraceHelper_ = function(fn, visited) {
       }
 
       if (argDesc.length > 40) {
-        argDesc = argDesc.substr(0, 40) + '...';
+        argDesc = argDesc.slice(0, 40) + '...';
       }
       sb.push(argDesc);
     }

--- a/closure/goog/debug/devcss/devcss.js
+++ b/closure/goog/debug/devcss/devcss.js
@@ -396,7 +396,7 @@ goog.debug.DevCss.prototype.getIe6CombinedSelectorText_ = function(cssText) {
     const groupedSelectors = combinedSelectorText.split(/\s*\,\s*/);
     for (let i = 0, selector; selector = groupedSelectors[i]; i++) {
       // Strips off the leading ".".
-      const combinedClassName = selector.substr(1);
+      const combinedClassName = selector.slice(1);
       const classNames = combinedClassName.split(
           goog.debug.DevCss.CssToken_.IE6_COMBINED_GLUE);
       const entry = {

--- a/closure/goog/dom/annotate.js
+++ b/closure/goog/dom/annotate.js
@@ -314,12 +314,12 @@ goog.dom.annotate.helpAnnotateText_ = function(
       termHits[termIndexOfNextHit].shift();
 
       // Append everything from the end of the last hit up to this one.
-      html.push(text.substr(pos, posOfNextHit - pos));
+      html.push(text.slice(pos, posOfNextHit));
 
       // Append the annotated term.
       var termLen = terms[termIndexOfNextHit][0].length;
       var termHtml =
-          goog.html.SafeHtml.htmlEscape(text.substr(posOfNextHit, termLen));
+          goog.html.SafeHtml.htmlEscape(text.slice(posOfNextHit, posOfNextHit + termLen));
       html.push(
           annotateFn(goog.asserts.assertNumber(termIndexOfNextHit), termHtml));
 
@@ -327,7 +327,7 @@ goog.dom.annotate.helpAnnotateText_ = function(
     }
 
     // Append everything after the last hit.
-    html.push(text.substr(pos));
+    html.push(text.slice(pos));
     return goog.html.SafeHtml.concat(html);
   } else {
     return null;

--- a/closure/goog/dom/browserrange/abstractrange.js
+++ b/closure/goog/dom/browserrange/abstractrange.js
@@ -257,7 +257,7 @@ goog.dom.browserrange.AbstractRange.prototype.getHtmlFragment = function() {
           output.append(html);
         } else {
           var index = html.lastIndexOf('<');
-          output.append(index ? html.substr(0, index) : html);
+          output.append(index !== -1 ? html.slice(0, index) : html);
         }
       }
     }

--- a/closure/goog/dom/browserrange/abstractrange.js
+++ b/closure/goog/dom/browserrange/abstractrange.js
@@ -257,7 +257,12 @@ goog.dom.browserrange.AbstractRange.prototype.getHtmlFragment = function() {
           output.append(html);
         } else {
           var index = html.lastIndexOf('<');
-          output.append(index !== -1 ? html.slice(0, index) : html);
+          // if index is -1, then this appends nothing.
+          // if index is 0, then the entire HTML content should be added.
+          // if the index is > 0, then only the portion of the html before the last open tag is appended.
+          if (index !== -1) {
+            output.append(index > 0 ? html.slice(0, index) : html);
+          }
         }
       }
     }

--- a/closure/goog/dom/dataset.js
+++ b/closure/goog/dom/dataset.js
@@ -186,8 +186,8 @@ goog.dom.dataset.getAll = function(element) {
     for (var i = 0; i < attributes.length; ++i) {
       var attribute = attributes[i];
       if (goog.string.startsWith(attribute.name, goog.dom.dataset.PREFIX_)) {
-        // We use substr(5), since it's faster than replacing 'data-' with ''.
-        var key = goog.string.toCamelCase(attribute.name.substr(5));
+        // We use slice(5), since it's faster than replacing 'data-' with ''.
+        var key = goog.string.toCamelCase(attribute.name.slice(5));
         dataset[key] = attribute.value;
       }
     }

--- a/closure/goog/dom/selection.js
+++ b/closure/goog/dom/selection.js
@@ -245,8 +245,8 @@ goog.dom.selection.setText = function(textfield, text) {
   if (goog.dom.selection.useSelectionProperties_(textfield)) {
     var value = textfield.value;
     var oldSelectionStart = textfield.selectionStart;
-    var before = value.substr(0, oldSelectionStart);
-    var after = value.substr(textfield.selectionEnd);
+    var before = value.slice(0, oldSelectionStart);
+    var after = value.slice(textfield.selectionEnd);
     textfield.value = before + text + after;
     textfield.selectionStart = oldSelectionStart;
     textfield.selectionEnd = oldSelectionStart + text.length;

--- a/closure/goog/editor/range_test.js
+++ b/closure/goog/editor/range_test.js
@@ -64,8 +64,8 @@ function clearSelectionAndRestoreSaved(saved) {
 }
 
 function manualSplitText(node, pos) {
-  const newNodeString = node.nodeValue.substr(pos);
-  node.nodeValue = node.nodeValue.substr(0, pos);
+  const newNodeString = node.nodeValue.slice(pos);
+  node.nodeValue = node.nodeValue.slice(0, pos);
   dom.insertSiblingAfter(document.createTextNode(newNodeString), node);
 }
 

--- a/closure/goog/format/format.js
+++ b/closure/goog/format/format.js
@@ -392,7 +392,7 @@ goog.format.insertWordBreaksGeneric_ = function(
   }
 
   // Take care of anything we haven't flushed so far.
-  rv.push(str.substr(lastDumpPosition));
+  rv.push(str.slice(lastDumpPosition));
 
   return rv.join('');
 };

--- a/closure/goog/history/html5history.js
+++ b/closure/goog/history/html5history.js
@@ -148,7 +148,7 @@ goog.history.Html5History.prototype.getToken = function() {
     return this.transformer_ ?
         this.transformer_.retrieveToken(
             this.pathPrefix_, this.window_.location) :
-        this.window_.location.pathname.substr(this.pathPrefix_.length);
+        this.window_.location.pathname.slice(this.pathPrefix_.length);
   }
 };
 

--- a/closure/goog/i18n/datetimeformat.js
+++ b/closure/goog/i18n/datetimeformat.js
@@ -828,7 +828,7 @@ goog.i18n.DateTimeFormat.prototype.formatFractionalSeconds_ = function(
   const value =
       /** @type {!Date|!goog.date.DateTime} */ (date).getMilliseconds() / 1000;
   return this.localizeNumbers_(
-      value.toFixed(Math.min(3, count)).substr(2) +
+      value.toFixed(Math.min(3, count)).slice(2) +
       (count > 3 ? goog.string.padNumber(0, count - 3) : ''));
 };
 

--- a/closure/goog/i18n/numberformat_test.js
+++ b/closure/goog/i18n/numberformat_test.js
@@ -180,7 +180,7 @@ testSuite({
       fmt = new NumberFormat(NumberFormat.Format.DECIMAL);
       str = fmt.format(-1.234567890123456e306);
       assertEquals(1 + 1 + 306 + 306 / 3, str.length);
-      assertEquals('-1,234,567,890,123,45', str.substr(0, 21));
+      assertEquals('-1,234,567,890,123,45', str.slice(0, 21));
 
       str = fmt.format(Infinity);
       assertEquals('\u221e', str);

--- a/closure/goog/json/json.js
+++ b/closure/goog/json/json.js
@@ -320,7 +320,7 @@ goog.json.Serializer.prototype.serializeString_ = function(s, sb) {
     // caching the result improves performance by a factor 2-3
     let rv = goog.json.Serializer.charToJsonCharCache_[c];
     if (!rv) {
-      rv = '\\u' + (c.charCodeAt(0) | 0x10000).toString(16).substr(1);
+      rv = '\\u' + (c.charCodeAt(0) | 0x10000).toString(16).slice(1);
       goog.json.Serializer.charToJsonCharCache_[c] = rv;
     }
     return rv;

--- a/closure/goog/labs/net/webchannel/channelrequest.js
+++ b/closure/goog/labs/net/webchannel/channelrequest.js
@@ -1051,7 +1051,7 @@ ChannelRequest.prototype.getNextChunk_ = function(responseText) {
     return ChannelRequest.INCOMPLETE_CHUNK_;
   }
 
-  const chunkText = responseText.substr(chunkStartIndex, size);
+  const chunkText = responseText.slice(chunkStartIndex, chunkStartIndex + size);
   this.xmlHttpChunkStart_ = chunkStartIndex + size;
   return chunkText;
 };

--- a/closure/goog/log/log.js
+++ b/closure/goog/log/log.js
@@ -748,7 +748,7 @@ goog.log.LogRegistry_ = class LogRegistry_ {
 
       // Get its parent first.
       const lastDotIndex = name.lastIndexOf('.');
-      const parentName = name.substr(0, lastDotIndex);
+      const parentName = name.slice(0, lastDotIndex !== -1 ? lastDotIndex : 0);
       const parentLogRegistryEntry = this.getLogRegistryEntry(parentName);
 
       // Now create the new entry, linking it with its parent.

--- a/closure/goog/math/long.js
+++ b/closure/goog/math/long.js
@@ -122,7 +122,7 @@ class Long {
     if (digits.length < safeDigits) {
       // Up to 13 leading 0s we might need to insert as the greatest safeDigits
       // value is 14 (for radix 2).
-      digits = '0000000000000'.substr(digits.length - safeDigits) + digits;
+      digits = '0000000000000'.slice(digits.length - safeDigits) + digits;
     }
 
     val = remDiv.toNumber();

--- a/closure/goog/net/channelrequest.js
+++ b/closure/goog/net/channelrequest.js
@@ -886,7 +886,7 @@ goog.net.ChannelRequest.prototype.getNextChunk_ = function(responseText) {
     return goog.net.ChannelRequest.INCOMPLETE_CHUNK_;
   }
 
-  const chunkText = responseText.substr(chunkStartIndex, size);
+  const chunkText = responseText.slice(chunkStartIndex, chunkStartIndex + size);
   this.xmlHttpChunkStart_ = chunkStartIndex + size;
   return chunkText;
 };

--- a/closure/goog/net/cookies.js
+++ b/closure/goog/net/cookies.js
@@ -244,7 +244,7 @@ goog.net.Cookies.prototype.get = function(name, opt_default) {
     part = goog.string.trim(parts[i]);
     // startsWith
     if (part.lastIndexOf(nameEq, 0) == 0) {
-      return part.substr(nameEq.length);
+      return part.slice(nameEq.length);
     }
     if (part == name) {
       return '';

--- a/closure/goog/net/streams/base64streamdecoder.js
+++ b/closure/goog/net/streams/base64streamdecoder.js
@@ -111,13 +111,13 @@ Decoder.prototype.decode = function(input) {
   let result;
   try {
     result = goog.crypt.base64.decodeStringToByteArray(
-        this.leftoverInput_.substr(0, groups * 4));
+        this.leftoverInput_.slice(0, groups * 4));
   } catch (e) {
     this.error_(this.leftoverInput_, e.message);
   }
 
   this.streamPos_ += groups * 4;
-  this.leftoverInput_ = this.leftoverInput_.substr(groups * 4);
+  this.leftoverInput_ = this.leftoverInput_.slice(groups * 4);
   return result;
 };
 });  // goog.scope

--- a/closure/goog/net/streams/pbjsonstreamparser.js
+++ b/closure/goog/net/streams/pbjsonstreamparser.js
@@ -144,7 +144,7 @@ PbJsonStreamParser.prototype.parse = function(input) {
           parser.state_ = State.MESSAGES;
           resetJsonStreamParser();
           // Feed the '[' again in the next loop.
-        } else if (input[pos] === ',' || input.substr(pos, 5) == 'null,') {
+        } else if (input[pos] === ',' || input.slice(pos, pos + 5) == 'null,') {
           parser.state_ = State.MESSAGES_DONE;
           // Feed the ',' again in the next loop.
         } else if (input[pos] === ']') {
@@ -173,7 +173,7 @@ PbJsonStreamParser.prototype.parse = function(input) {
         break;
       }
       case State.MESSAGES_DONE: {
-        if (input[pos] === ',' || input.substr(pos, 5) == 'null,') {
+        if (input[pos] === ',' || input.slice(pos, pos + 5) == 'null,') {
           parser.state_ = State.STATUS;
           resetJsonStreamParser();
           // Feed a dummy "[" to match the ending "]".

--- a/closure/goog/net/streams/xhrstreamreader.js
+++ b/closure/goog/net/streams/xhrstreamreader.js
@@ -242,7 +242,7 @@ class XhrStreamReader {
         return;
       }
     } else if (responseText.length > this.pos_) {
-      const newData = responseText.substr(this.pos_);
+      const newData = responseText.slice(this.pos_);
       this.pos_ = responseText.length;
       try {
         const messages = this.parser_.parse(newData);

--- a/closure/goog/storage/mechanism/ieuserdata.js
+++ b/closure/goog/storage/mechanism/ieuserdata.js
@@ -156,7 +156,7 @@ goog.storage.mechanism.IEUserData.encodeKey_ = function(key) {
  */
 goog.storage.mechanism.IEUserData.decodeKey_ = function(key) {
   'use strict';
-  return decodeURIComponent(key.replace(/\./g, '%')).substr(1);
+  return decodeURIComponent(key.replace(/\./g, '%')).slice(1);
 };
 
 

--- a/closure/goog/storage/mechanism/prefixedmechanism.js
+++ b/closure/goog/storage/mechanism/prefixedmechanism.js
@@ -88,14 +88,14 @@ goog.storage.mechanism.PrefixedMechanism.prototype.__iterator__ = function(
     let it = subIter.next();
     if (it.done) return it;
     key = it.value;
-    while (key.substr(0, selfObj.prefix_.length) != selfObj.prefix_) {
+    while (key.slice(0, selfObj.prefix_.length) != selfObj.prefix_) {
       it = subIter.next();
       if (it.done) return it;
       key = it.value;
     }
     return goog.iter.createEs6IteratorYield(
         /** @type {string} */ (
-            opt_keys ? key.substr(selfObj.prefix_.length) :
+            opt_keys ? key.slice(selfObj.prefix_.length) :
                        selfObj.mechanism_.get(key)));
   };
 

--- a/closure/goog/string/internal.js
+++ b/closure/goog/string/internal.js
@@ -51,8 +51,9 @@ goog.string.internal.endsWith = function(str, suffix) {
  */
 goog.string.internal.caseInsensitiveStartsWith = function(str, prefix) {
   'use strict';
-  return goog.string.internal.caseInsensitiveCompare(
-             prefix, str.slice(0, prefix.length)) == 0;
+  return (prefix.length == 0 ||
+      goog.string.internal.caseInsensitiveCompare(
+          prefix, str.slice(0, prefix.length)) == 0);
 };
 
 
@@ -66,7 +67,7 @@ goog.string.internal.caseInsensitiveStartsWith = function(str, prefix) {
  */
 goog.string.internal.caseInsensitiveEndsWith = function(str, suffix) {
   'use strict';
-  return (
+  return (suffix.length == 0 ||
       goog.string.internal.caseInsensitiveCompare(
           suffix, str.slice(-suffix.length)) == 0);
 };

--- a/closure/goog/string/internal.js
+++ b/closure/goog/string/internal.js
@@ -52,7 +52,7 @@ goog.string.internal.endsWith = function(str, suffix) {
 goog.string.internal.caseInsensitiveStartsWith = function(str, prefix) {
   'use strict';
   return goog.string.internal.caseInsensitiveCompare(
-             prefix, str.substr(0, prefix.length)) == 0;
+             prefix, str.slice(0, prefix.length)) == 0;
 };
 
 
@@ -68,7 +68,7 @@ goog.string.internal.caseInsensitiveEndsWith = function(str, suffix) {
   'use strict';
   return (
       goog.string.internal.caseInsensitiveCompare(
-          suffix, str.substr(str.length - suffix.length, suffix.length)) == 0);
+          suffix, str.slice(-suffix.length)) == 0);
 };
 
 

--- a/closure/goog/string/path.js
+++ b/closure/goog/string/path.js
@@ -68,7 +68,7 @@ goog.string.path.extension = function(path) {
   // Combining all adjacent periods in the basename to a single period.
   const baseName = goog.string.path.baseName(path).replace(/\.+/g, separator);
   const separatorIndex = baseName.lastIndexOf(separator);
-  return separatorIndex <= 0 ? '' : baseName.substr(separatorIndex + 1);
+  return separatorIndex <= 0 ? '' : baseName.slice(separatorIndex + 1);
 };
 
 

--- a/closure/goog/string/string.js
+++ b/closure/goog/string/string.js
@@ -653,7 +653,7 @@ goog.string.unescapeEntitiesUsingDom_ = function(str, opt_document) {
     // Check for numeric entity.
     if (entity.charAt(0) == '#') {
       // Prefix with 0 so that hex entities (e.g. &#x10) parse as hex numbers.
-      const n = Number('0' + entity.substr(1));
+      const n = Number('0' + entity.slice(1));
       if (!isNaN(n)) {
         value = String.fromCharCode(n);
       }
@@ -698,7 +698,7 @@ goog.string.unescapePureXmlEntities_ = function(str) {
       default:
         if (entity.charAt(0) == '#') {
           // Prefix with 0 so that hex entities (e.g. &#x10) parse as hex.
-          const n = Number('0' + entity.substr(1));
+          const n = Number('0' + entity.slice(1));
           if (!isNaN(n)) {
             return String.fromCharCode(n);
           }
@@ -998,8 +998,7 @@ goog.string.removeAt = function(s, index, stringLength) {
   let resultStr = s;
   // If the index is greater or equal to 0 then remove substring
   if (index >= 0 && index < s.length && stringLength > 0) {
-    resultStr = s.substr(0, index) +
-        s.substr(index + stringLength, s.length - index - stringLength);
+    resultStr = s.slice(0, index) + s.slice(index + stringLength);
   }
   return resultStr;
 };
@@ -1336,7 +1335,7 @@ goog.string.toTitleCase = function(str, opt_delimiters) {
 goog.string.capitalize = function(str) {
   'use strict';
   return String(str.charAt(0)).toUpperCase() +
-      String(str.substr(1)).toLowerCase();
+      String(str.slice(1)).toLowerCase();
 };
 
 

--- a/closure/goog/structs/set.js
+++ b/closure/goog/structs/set.js
@@ -77,7 +77,7 @@ goog.structs.Set.getKey_ = function(val) {
   if (type == 'object' && val || type == 'function') {
     return 'o' + goog.structs.Set.getUid_(/** @type {Object} */ (val));
   } else {
-    return type.substr(0, 1) + val;
+    return type.slice(0, 1) + val;
   }
 };
 

--- a/closure/goog/structs/stringset.js
+++ b/closure/goog/structs/stringset.js
@@ -92,7 +92,7 @@ goog.structs.StringSet.encode_ = function(element) {
  */
 goog.structs.StringSet.decode_ = function(key) {
   'use strict';
-  return key.charCodeAt(0) == 32 ? key.substr(1) : key;
+  return key.charCodeAt(0) == 32 ? key.slice(1) : key;
 };
 
 

--- a/closure/goog/testing/asserts.js
+++ b/closure/goog/testing/asserts.js
@@ -137,7 +137,7 @@ var _trueTypeOf = function(something) {
     }
   } catch (e) {
   } finally {
-    result = result.substr(0, 1).toUpperCase() + result.substr(1);
+    result = result.slice(0, 1).toUpperCase() + result.slice(1);
   }
   return result;
 };
@@ -383,7 +383,7 @@ goog.testing.asserts.removeOperaStacktrace_ = function(e) {
       typeof e['message'] === 'string') {
     var startIndex = e['message'].length - e['stacktrace'].length;
     if (e['message'].indexOf(e['stacktrace'], startIndex) == startIndex) {
-      e['message'] = e['message'].substr(0, startIndex - 14);
+      e['message'] = e['message'].slice(0, -e['stacktrace'].length - 14);
     }
   }
 };

--- a/closure/goog/testing/dom.js
+++ b/closure/goog/testing/dom.js
@@ -89,7 +89,7 @@ goog.testing.dom.assertNodesMatch = function(
       assertEquals(
           'Expected element at position ' + i, goog.dom.NodeType.ELEMENT,
           node.nodeType);
-      const expectedId = expected.substr(1);
+      const expectedId = expected.slice(1);
       assertEquals('IDs should match at position ' + i, expectedId, node.id);
 
     } else {
@@ -175,7 +175,7 @@ goog.testing.dom.checkUserAgents_ = function(userAgents) {
     if (goog.string.contains(userAgents, ' ')) {
       throw new Error('Only a single negative user agent may be specified');
     }
-    return !goog.userAgent[userAgents.substr(1)];
+    return !goog.userAgent[userAgents.slice(1)];
   }
 
   var agents = userAgents.split(' ');

--- a/closure/goog/testing/editor/dom.js
+++ b/closure/goog/testing/editor/dom.js
@@ -259,8 +259,8 @@ goog.testing.editor.dom.getTextFollowingRange_ = function(
     if (isBefore ? endpointOffset > 0 : endpointOffset < endText.length) {
       // There is text in this node following the endpoint so return the portion
       // that follows the endpoint.
-      return isBefore ? endText.substr(0, endpointOffset) :
-                        endText.substr(endpointOffset);
+      return isBefore ? endText.slice(0, endpointOffset) :
+                        endText.slice(endpointOffset);
     } else {
       // There is no text following the endpoint so look for the follwing text
       // node.

--- a/closure/goog/testing/testcase.js
+++ b/closure/goog/testing/testcase.js
@@ -1767,7 +1767,7 @@ goog.testing.TestCase.prototype.getTimeStamp_ = function() {
 
   // Ensure millis are always 3-digits
   var millis = '00' + d.getMilliseconds();
-  millis = millis.substr(millis.length - 3);
+  millis = millis.slice(-3);
 
   return this.pad_(d.getHours()) + ':' + this.pad_(d.getMinutes()) + ':' +
       this.pad_(d.getSeconds()) + '.' + millis;
@@ -2332,7 +2332,7 @@ goog.testing.TestCase.parseRunTests_ = function(href) {
     return null;
   }
 
-  const nonOriginParts = href.substr(queryParamIndex);
+  const nonOriginParts = href.slice(queryParamIndex);
 
   // Use a "fake" origin because tests may load using protocols that goog.url
   // doesn't support

--- a/closure/goog/testing/testrunner.js
+++ b/closure/goog/testing/testrunner.js
@@ -427,7 +427,7 @@ goog.testing.TestRunner.prototype.writeLog = function(log) {
     if (line == '') {
       line = '\n';
     }
-    if (line.substr(0, 2) == '> ') {
+    if (line.slice(0, 2) == '> ') {
       // The stack trace may contain links so it has to be interpreted as HTML.
       div.innerHTML = line;
     } else {
@@ -450,8 +450,8 @@ goog.testing.TestRunner.prototype.writeLog = function(log) {
       if (search) {
         var oldTests = /runTests=([^&]*)/.exec(search);
         if (oldTests) {
-          newSearch = search.substr(0, oldTests.index) + newSearch +
-              search.substr(oldTests.index + oldTests[0].length);
+          newSearch = search.slice(0, oldTests.index) + newSearch +
+              search.slice(oldTests.index + oldTests[0].length);
         } else {
           newSearch = search + '&' + newSearch;
         }

--- a/closure/goog/tweak/entries.js
+++ b/closure/goog/tweak/entries.js
@@ -987,7 +987,7 @@ goog.tweak.BooleanGroup.prototype.initialize = function(value) {
       var token = tokens[i].toLowerCase();
       var negative = token.charAt(0) == '-';
       if (negative) {
-        token = token.substr(1);
+        token = token.slice(1);
       }
       queryParamValues[token] = !negative;
     }

--- a/closure/goog/tweak/registry.js
+++ b/closure/goog/tweak/registry.js
@@ -76,7 +76,7 @@ goog.tweak.Registry.prototype.logger_ =
 goog.tweak.Registry.parseQueryParams = function(queryParams) {
   'use strict';
   // Strip off the leading ? and split on &.
-  var parts = queryParams.substr(1).split('&');
+  var parts = queryParams.slice(1).split('&');
   var ret = {};
 
   for (var i = 0, il = parts.length; i < il; ++i) {

--- a/closure/goog/tweak/tweakui.js
+++ b/closure/goog/tweak/tweakui.js
@@ -269,7 +269,7 @@ goog.tweak.TweakUi.getNamespacedLabel_ = function(entry) {
   'use strict';
   var label = entry.label;
   if (label == entry.getId()) {
-    label = label.substr(label.lastIndexOf('.') + 1);
+    label = label.slice(label.lastIndexOf('.') + 1);
   }
   return label;
 };

--- a/closure/goog/ui/abstractspellchecker.js
+++ b/closure/goog/ui/abstractspellchecker.js
@@ -1047,7 +1047,7 @@ goog.ui.AbstractSpellChecker.prototype.processTextAsync = function(node, text) {
       var status = this.spellCheck.checkWord(word);
       if (status != goog.spell.SpellCheck.WordStatus.VALID) {
         var precedingText =
-            text.substr(stringSegmentStart, result.index - stringSegmentStart);
+            text.slice(stringSegmentStart, result.index);
         if (precedingText) {
           this.processRange(node, precedingText);
         }
@@ -1065,7 +1065,7 @@ goog.ui.AbstractSpellChecker.prototype.processTextAsync = function(node, text) {
     }
   }
 
-  var leftoverText = text.substr(stringSegmentStart);
+  var leftoverText = text.slice(stringSegmentStart);
   if (leftoverText) {
     this.processRange(node, leftoverText);
   }
@@ -1101,7 +1101,7 @@ goog.ui.AbstractSpellChecker.prototype.continueAsyncProcessing = function() {
       var status = this.spellCheck.checkWord(word);
       if (status != goog.spell.SpellCheck.WordStatus.VALID) {
         var precedingText =
-            text.substr(stringSegmentStart, result.index - stringSegmentStart);
+            text.slice(stringSegmentStart, result.index);
         if (precedingText) {
           this.processRange(node, precedingText);
         }
@@ -1120,7 +1120,7 @@ goog.ui.AbstractSpellChecker.prototype.continueAsyncProcessing = function() {
   this.asyncRangeStart_ = 0;
   delete this.asyncNode_;
 
-  var leftoverText = text.substr(stringSegmentStart);
+  var leftoverText = text.slice(stringSegmentStart);
   if (leftoverText) {
     this.processRange(node, leftoverText);
   }

--- a/closure/goog/ui/combobox.js
+++ b/closure/goog/ui/combobox.js
@@ -1021,10 +1021,10 @@ goog.ui.ComboBoxItem.prototype.setFormatFromToken = function(token) {
     if (index >= 0) {
       var domHelper = this.getDomHelper();
       this.setContent([
-        domHelper.createTextNode(caption.substr(0, index)),
+        domHelper.createTextNode(caption.slice(0, index)),
         domHelper.createDom(
-            goog.dom.TagName.B, null, caption.substr(index, token.length)),
-        domHelper.createTextNode(caption.substr(index + token.length))
+            goog.dom.TagName.B, null, caption.slice(index, index + token.length)),
+        domHelper.createTextNode(caption.slice(index + token.length))
       ]);
     }
   }

--- a/closure/goog/ui/editor/defaulttoolbar.js
+++ b/closure/goog/ui/editor/defaulttoolbar.js
@@ -584,7 +584,7 @@ goog.ui.editor.DefaultToolbar.colorUpdateFromValue_ = function(button, color) {
       // IE returns a number that, converted to hex, is a BGR color.
       // Convert from decimal to BGR to RGB.
       const hex = '000000' + value.toString(16);
-      const bgr = hex.substr(hex.length - 6, 6);
+      const bgr = hex.slice(-6);
       value =
           '#' + bgr.substring(4, 6) + bgr.substring(2, 4) + bgr.substring(0, 2);
     }

--- a/closure/goog/ui/filteredmenu.js
+++ b/closure/goog/ui/filteredmenu.js
@@ -454,7 +454,7 @@ goog.ui.FilteredMenu.prototype.filterItems_ = function(str) {
 
     // If the number of comma separated items has changes recreate the
     // entered items array and fire a change event.
-    if (str.substr(str.length - 1, 1) == ',' ||
+    if (str.slice(-1) == ',' ||
         items.length != this.enteredItems_.length) {
       var lastItem = items[items.length - 1] || '';
 
@@ -525,9 +525,9 @@ goog.ui.FilteredMenu.prototype.boldContent = function(child, start, len) {
   if (len == 0) {
     boldedCaption = this.getDomHelper().createTextNode(caption);
   } else {
-    var preMatch = caption.substr(0, start);
-    var match = caption.substr(start, len);
-    var postMatch = caption.substr(start + len);
+    var preMatch = caption.slice(0, start);
+    var match = caption.slice(start, start + len);
+    var postMatch = caption.slice(start + len);
     boldedCaption = this.getDomHelper().createDom(
         goog.dom.TagName.SPAN, null, preMatch,
         this.getDomHelper().createDom(goog.dom.TagName.B, null, match),

--- a/closure/goog/ui/plaintextspellchecker.js
+++ b/closure/goog/ui/plaintextspellchecker.js
@@ -332,7 +332,7 @@ goog.ui.PlainTextSpellChecker.prototype.initTextArray_ = function(text) {
     }
     var excludedRange = result[0];
     var includedRange =
-        text.substr(stringSegmentStart, result.index - stringSegmentStart);
+        text.slice(stringSegmentStart, result.index);
     if (includedRange) {
       this.textArray_.push(includedRange);
       this.textArrayProcess_.push(true);
@@ -342,7 +342,7 @@ goog.ui.PlainTextSpellChecker.prototype.initTextArray_ = function(text) {
     stringSegmentStart = this.excludeMarker.lastIndex;
   }
 
-  var leftoverText = text.substr(stringSegmentStart);
+  var leftoverText = text.slice(stringSegmentStart);
   if (leftoverText) {
     this.textArray_.push(leftoverText);
     this.textArrayProcess_.push(true);

--- a/closure/goog/uri/uri.js
+++ b/closure/goog/uri/uri.js
@@ -291,7 +291,7 @@ goog.Uri.prototype.resolve = function(relativeUri) {
           // RFC 3986, section 5.2.3, case 2
           var lastSlashIndex = absoluteUri.getPath().lastIndexOf('/');
           if (lastSlashIndex != -1) {
-            path = absoluteUri.getPath().substr(0, lastSlashIndex + 1) + path;
+            path = absoluteUri.getPath().slice(0, lastSlashIndex + 1) + path;
           }
         }
       }

--- a/closure/goog/uri/uri_test.js
+++ b/closure/goog/uri/uri_test.js
@@ -1009,7 +1009,7 @@ testSuite({
     let fragment = new Uri().setFragment(testString).toString();
 
     // Remove first '#' character.
-    fragment = fragment.substr(1);
+    fragment = fragment.slice(1);
 
     // Strip all percent encoded characters, as they're ok.
     fragment = fragment.replace(/%[0-9A-F][0-9A-F]/g, '');

--- a/closure/goog/uri/utils.js
+++ b/closure/goog/uri/utils.js
@@ -326,7 +326,7 @@ goog.uri.utils.getEffectiveScheme = function(uri) {
   var scheme = goog.uri.utils.getScheme(uri);
   if (!scheme && goog.global.self && goog.global.self.location) {
     var protocol = goog.global.self.location.protocol;
-    scheme = protocol.substr(0, protocol.length - 1);
+    scheme = protocol.slice(0, -1);
   }
   // NOTE: When called from a web worker in Firefox 3.5, location may be null.
   // All other browsers with web workers support self.location from the worker.
@@ -440,7 +440,7 @@ goog.uri.utils.getFragmentEncoded = function(uri) {
   'use strict';
   // The hash mark may not appear in any other part of the URL.
   var hashIndex = uri.indexOf('#');
-  return hashIndex < 0 ? null : uri.substr(hashIndex + 1);
+  return hashIndex < 0 ? null : uri.slice(hashIndex + 1);
 };
 
 
@@ -524,7 +524,7 @@ goog.uri.utils.removeFragment = function(uri) {
   'use strict';
   // The hash mark may not appear in any other part of the URL.
   var hashIndex = uri.indexOf('#');
-  return hashIndex < 0 ? uri : uri.substr(0, hashIndex);
+  return hashIndex < 0 ? uri : uri.slice(0, hashIndex);
 };
 
 
@@ -664,7 +664,7 @@ goog.uri.utils.splitQueryData_ = function(uri) {
   } else {
     queryData = uri.substring(questionIndex + 1, hashIndex);
   }
-  return [uri.substr(0, questionIndex), queryData, uri.substr(hashIndex)];
+  return [uri.slice(0, questionIndex), queryData, uri.slice(hashIndex)];
 };
 
 
@@ -955,10 +955,8 @@ goog.uri.utils.getParamValue = function(uri, keyEncoded) {
     }
     // Progress forth to the end of the "key=" or "key&" substring.
     foundIndex += keyEncoded.length + 1;
-    // Use substr, because it (unlike substring) will return empty string
-    // if foundIndex > endPosition.
     return goog.string.urlDecode(
-        uri.substr(foundIndex, endPosition - foundIndex));
+        uri.slice(foundIndex, endPosition !== -1 ? endPosition : 0));
   }
 };
 
@@ -988,10 +986,8 @@ goog.uri.utils.getParamValues = function(uri, keyEncoded) {
 
     // Progress forth to the end of the "key=" or "key&" substring.
     foundIndex += keyEncoded.length + 1;
-    // Use substr, because it (unlike substring) will return empty string
-    // if foundIndex > position.
-    result.push(
-        goog.string.urlDecode(uri.substr(foundIndex, position - foundIndex)));
+    result.push(goog.string.urlDecode(
+      uri.slice(foundIndex, position !== -1 ? position : 0)));
   }
 
   return result;
@@ -1032,7 +1028,7 @@ goog.uri.utils.removeParam = function(uri, keyEncoded) {
   }
 
   // Append everything that is remaining.
-  buffer.push(uri.substr(position));
+  buffer.push(uri.slice(position));
 
   // Join the buffer, and remove trailing punctuation that remains.
   return buffer.join('').replace(
@@ -1082,7 +1078,7 @@ goog.uri.utils.setParamsFromMap = function(uri, params) {
     queryData.split('&').forEach(function(pair) {
       'use strict';
       var indexOfEquals = pair.indexOf('=');
-      var name = indexOfEquals >= 0 ? pair.substr(0, indexOfEquals) : pair;
+      var name = indexOfEquals >= 0 ? pair.slice(0, indexOfEquals) : pair;
       if (!params.hasOwnProperty(name)) {
         buffer.push(pair);
       }
@@ -1110,11 +1106,11 @@ goog.uri.utils.appendPath = function(baseUri, path) {
 
   // Remove any trailing '/'
   if (goog.string.endsWith(baseUri, '/')) {
-    baseUri = baseUri.substr(0, baseUri.length - 1);
+    baseUri = baseUri.slice(0, -1);
   }
   // Remove any leading '/'
   if (goog.string.startsWith(path, '/')) {
-    path = path.substr(1);
+    path = path.slice(1);
   }
   return '' + baseUri + '/' + path;
 };


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.