### PR TITLE
fix: Normalize paths on Windows.

### DIFF
--- a/closure-deps/lib/depfile.js
+++ b/closure-deps/lib/depfile.js
@@ -18,6 +18,8 @@
 const depGraph = require('./depgraph');
 const path = require('path');
 
+const {normalizePath} = require('./normalize');
+
 /**
  * Gets the text of a dependency file for the given dependencies.
  *
@@ -34,7 +36,7 @@ const getDepFileText = exports.getDepFileText = (
   for (const dep of dependencies) {
     const args = [];
 
-    args.push(`'${path.posix.relative(pathToClosure, dep.path)}'`);
+    args.push(`'${normalizePath(path.relative(pathToClosure, dep.path))}'`);
     args.push(`[${dep.closureSymbols.map(s => `'${s}'`).join(', ')}]`);
     const requires = [];
     for (const imported of dep.imports) {
@@ -44,7 +46,7 @@ const getDepFileText = exports.getDepFileText = (
         const requiredFilePath =
             moduleResolver.resolve(dep.path, imported.symOrPath);
         const relativePath = path.relative(pathToClosure, requiredFilePath);
-        requires.push(relativePath);
+        requires.push(normalizePath(relativePath));
       }
     }
     args.push(`[${requires.map(s => `'${s}'`).join(', ')}]`);

--- a/closure-deps/lib/depgraph.js
+++ b/closure-deps/lib/depgraph.js
@@ -18,6 +18,8 @@
 const {SourceError} = require('./sourceerror');
 const path = require('path');
 
+const {normalizePath} = require('./normalize');
+
 /** @enum {string} */
 const DependencyType = {
   /** A file containing goog.provide statements. */
@@ -144,7 +146,7 @@ class ParsedDependency extends Dependency {
 
   /** @override */
   setClosurePath(closurePath) {
-    this.path_ = path.resolve(closurePath, this.closureRelativePath);
+    this.path_ = normalizePath(path.resolve(closurePath, this.closureRelativePath));
   }
 
   /** @override */
@@ -308,6 +310,8 @@ class Graph {
         throw new Error('File registered twice? ' + dep.path);
       }
       this.depsByPath.set(dep.path, dep);
+      // Keep both OS-dependent path and POSIX style path.
+      this.depsByPath.set(normalizePath(dep.path), dep);
       for (const sym of dep.closureSymbols) {
         const previous = this.depsBySymbol.get(sym);
         if (previous) {

--- a/closure-deps/lib/normalize.js
+++ b/closure-deps/lib/normalize.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2022 The Closure Library Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+
+/**
+ * Escape regular expression pattern by making the following replacements:
+ *  * single backslash -> double backslash
+ * @param {string} pattern 
+ * @returns {string}
+ */
+function escapePattern(pattern) {
+  return pattern.replace(/\\/g, '\\\\');
+}
+
+/**
+ * Replaces OS-specific path with POSIX style path.
+ * @param {string} p 
+ * @returns {string}
+ */
+exports.normalizePath = (p) => {
+  const root = new RegExp(escapePattern(`^${path.resolve('/')}`));
+  const osSpecificSep = new RegExp(escapePattern(path.sep), 'g');
+  return p.replace(root, path.posix.sep).replace(osSpecificSep, path.posix.sep);
+};

--- a/closure-deps/spec/tests/closuremakedeps_test.js
+++ b/closure-deps/spec/tests/closuremakedeps_test.js
@@ -21,6 +21,8 @@ const fs = require('fs');
 const jasmineDiff = require('jasmine-diff');
 const os = require('os');
 
+const {normalizePath} = require('../../lib/normalize');
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 100000;
 
 // By default assume this is running based on the structure of the git repo.
@@ -59,7 +61,7 @@ function sortLines(str) {
 
 describe('closure-make-deps', function() {
   const tempFile = path.join(os.tmpdir(), 'closuremakejsdepstmp.js');
-  const tempFileRelativePath = path.relative(CLOSURE_PATH, tempFile);
+  const tempFileRelativePath = normalizePath(path.relative(CLOSURE_PATH, tempFile));
 
   const closureDepsContents =
       fs.readFileSync(path.resolve(CLOSURE_PATH, 'deps.js'), {

--- a/closure-deps/spec/tests/depgraph_test.js
+++ b/closure-deps/spec/tests/depgraph_test.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+const path = require('path');
 const depGraph = require('../../lib/depgraph');
 
 /**
@@ -228,7 +229,7 @@ describe('depgraph', function() {
       it('custom id', function() {
         const resolver = new (class extends depGraph.ModuleResolver {
           resolve(from, to) {
-            expect(from).toEqual('/example.js');
+            expect(from).toEqual(path.resolve('/example.js'));
             expect(to).toEqual('@wacky+id');
             return '/required.js';
           }


### PR DESCRIPTION
### Resolves

#1159 

### Proposed Changes

Fixed to generate a dependency on a POSIX style path.

In "depswriter.py", the path is normalized by the following code.

https://github.com/google/closure-library/blob/master/closure/bin/build/depswriter.py#L125-L136


Fixed the test code so that the `npm run test` of ` closure-deps` completes successfully on Windows.
