### PR TITLE
Fix undisposed object in linkbubble.js

### DIFF
--- a/closure/goog/editor/plugins/linkbubble.js
+++ b/closure/goog/editor/plugins/linkbubble.js
@@ -64,6 +64,7 @@ goog.editor.plugins.LinkBubble = function(var_args) {
 
   /** @private @const {!goog.a11y.aria.Announcer} */
   this.announcer_ = new goog.a11y.aria.Announcer();
+  this.registerDisposable(this.announcer_);
 };
 goog.inherits(
     goog.editor.plugins.LinkBubble, goog.editor.plugins.AbstractBubblePlugin);


### PR DESCRIPTION
`announcer_` in `goog.editor.plugins.LinkBubble` is not disposed with the component.
This pull request fixes it.

It was added by ccae5f3.