### PR TITLE
Fix zh locale i18n strings for 0 minutes and 0 hours

### DIFF
--- a/closure/goog/i18n/relativedatetimesymbols.js
+++ b/closure/goog/i18n/relativedatetimesymbols.js
@@ -9893,14 +9893,14 @@ exports.RelativeDateTimeSymbols_zh =  {
   },
   HOUR: {
     LONG:{
-      R:{'0':'这一时间 / 此时'},
+      R:{'0':'本小时'},
       P:'other{#小时前}',
       F:'other{#小时后}',
     },
   },
   MINUTE: {
     LONG:{
-      R:{'0':'此刻'},
+      R:{'0':'刚刚'},
       P:'other{#分钟前}',
       F:'other{#分钟后}',
     },

--- a/closure/goog/i18n/relativedatetimesymbolsext.js
+++ b/closure/goog/i18n/relativedatetimesymbolsext.js
@@ -26057,14 +26057,14 @@ exports.RelativeDateTimeSymbols_zh_Hans_HK =  {
   },
   HOUR: {
     LONG:{
-      R:{'0':'这一时间 / 此时'},
+      R:{'0':'本小时'},
       P:'other{#小时前}',
       F:'other{#小时后}',
     },
   },
   MINUTE: {
     LONG:{
-      R:{'0':'此刻'},
+      R:{'0':'刚刚'},
       P:'other{#分钟前}',
       F:'other{#分钟后}',
     },
@@ -26117,14 +26117,14 @@ exports.RelativeDateTimeSymbols_zh_Hans_MO =  {
   },
   HOUR: {
     LONG:{
-      R:{'0':'这一时间 / 此时'},
+      R:{'0':'本小时'},
       P:'other{#小时前}',
       F:'other{#小时后}',
     },
   },
   MINUTE: {
     LONG:{
-      R:{'0':'此刻'},
+      R:{'0':'刚刚'},
       P:'other{#分钟前}',
       F:'other{#分钟后}',
     },
@@ -26177,14 +26177,14 @@ exports.RelativeDateTimeSymbols_zh_Hans_SG =  {
   },
   HOUR: {
     LONG:{
-      R:{'0':'这一时间 / 此时'},
+      R:{'0':'本小时'},
       P:'other{#小时前}',
       F:'other{#小时后}',
     },
   },
   MINUTE: {
     LONG:{
-      R:{'0':'此刻'},
+      R:{'0':'刚刚'},
       P:'other{#分钟前}',
       F:'other{#分钟后}',
     },


### PR DESCRIPTION
`这一时间 / 此时` contains two strings those are not really usable.

`此刻` means `now` is the same as 0 second translation `现在`

In mandarin, we don't say anything similar to "this minute" or "this hour". The added `刚刚` is commonly used meaning "moment ago" or "just now".

I cannot find a good translation for `this hour`, I used simplified `本小时` from `zh_Hant_HK`.