### PR TITLE
Fix some low hanging fruit from issues/1191

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "io_bazel_rules_closure",
     sha256 = "9498e57368efb82b985db1ed426a767cbf1ba0398fd7aed632fc3908654e1b1e",
+    strip_prefix = "rules_closure-0.12.0",
     urls = [
         "https://github.com/bazelbuild/rules_closure/archive/refs/tags/0.12.0.tar.gz",  # 2021-06-23
     ],

--- a/closure/goog/i18n/BUILD
+++ b/closure/goog/i18n/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 closure_js_library(
     name = "jstests_deps",
     testonly = 1,
-    lenient = True,
     exports = [
         ":bidi",
         ":bidiformatter",

--- a/closure/goog/labs/net/BUILD
+++ b/closure/goog/labs/net/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 closure_js_library(
     name = "net",
     srcs = [],
-    lenient = True,
     exports = [
         ":image",
         ":webchannel",

--- a/closure/goog/labs/net/webchannel/BUILD
+++ b/closure/goog/labs/net/webchannel/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 closure_js_library(
     name = "webchannel",
     srcs = [],
-    lenient = True,
     exports = [
         ":webchannelbase",
         ":webchannelbasetransport",

--- a/closure/goog/labs/useragent/BUILD
+++ b/closure/goog/labs/useragent/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 closure_js_library(
     name = "useragent",
     srcs = [],
-    lenient = True,
     exports = [
         ":browser",
         ":device",

--- a/closure/goog/net/BUILD
+++ b/closure/goog/net/BUILD
@@ -310,6 +310,7 @@ closure_js_library(
     name = "mockiframeio",
     srcs = ["mockiframeio.js"],
     lenient = True,
+    testonly = True,
     deps = [
         ":errorcode",
         ":eventtype",

--- a/closure/goog/net/streams/BUILD
+++ b/closure/goog/net/streams/BUILD
@@ -7,7 +7,6 @@ licenses(["notice"])
 closure_js_library(
     name = "streams",
     srcs = [],
-    lenient = True,
     exports = [
         ":base64pbstreamparser",
         ":base64streamdecoder",

--- a/closure/goog/testing/BUILD
+++ b/closure/goog/testing/BUILD
@@ -288,7 +288,6 @@ closure_js_library(
 closure_js_library(
     name = "mockmatchers",
     testonly = True,
-    lenient = True,
     exports = [":mock"],
 )
 


### PR DESCRIPTION
https://github.com/google/closure-library/issues/1191

- Set `strip_prefix` for `@io_bazel_rules_closure` to allow build to progress further.
- Strip `lenient=1` from rules that don't allow it.
- Add `testonly=True` on a rule that requires it.